### PR TITLE
chore(dbt): remove unused json module import

### DIFF
--- a/converters/dbt/src/ossie_dbt/cli.py
+++ b/converters/dbt/src/ossie_dbt/cli.py
@@ -23,7 +23,6 @@ Usage:
 """
 
 import argparse
-import json
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
Remove unused `json` module import from dbt converter CLI.