### PR TITLE
test: add dbt converter snapshots

### DIFF
--- a/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_msi_to_osi.ambr
@@ -1,0 +1,184 @@
+# serializer version: 1
+# name: TestMetricConversion.test_derived_metric_nested
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+      - name: cost
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: cost_amount
+      - name: expenses
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: expense_amount
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+    - name: cost
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.cost_amount)
+    - name: expenses
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.expense_amount)
+    - name: gross_profit
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount) - SUM(orders.cost_amount)
+    - name: net_profit
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: (SUM(orders.amount) - SUM(orders.cost_amount)) - SUM(orders.expense_amount)
+  
+  '''
+# ---
+# name: TestMetricConversion.test_ratio_metric_inlines_sub_expressions
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+      - name: order_count
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: CASE WHEN order_id IS NOT NULL THEN 1 ELSE 0 END
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+    - name: order_count
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(CASE WHEN orders.order_id IS NOT NULL THEN 1 ELSE 0 END)
+    - name: arpu
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: (SUM(orders.amount)) / (SUM(CASE WHEN orders.order_id IS NOT NULL
+            THEN 1 ELSE 0 END))
+  
+  '''
+# ---
+# name: TestMetricFilterFlattening.test_metric_and_measure_filters_combined_with_and
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: schema.table
+      fields:
+      - name: revenue
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+    metrics:
+    - name: paid_intl_revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(CASE WHEN (status = 'paid') AND (region = 'intl') THEN orders.amount
+            END)
+  
+  '''
+# ---
+# name: TestRelationshipConversion.test_three_datasets_produce_all_pairs
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: users_a
+      source: schema.table
+      primary_key:
+      - user_id
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    - name: users_b
+      source: schema.table
+      unique_keys:
+      - - user_id
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    - name: orders
+      source: schema.table
+      fields:
+      - name: user
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: user_id
+    relationships:
+    - name: users_a__users_b__user
+      from: users_a
+      to: users_b
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+    - name: orders__users_a__user
+      from: orders
+      to: users_a
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+    - name: orders__users_b__user
+      from: orders
+      to: users_b
+      from_columns:
+      - user_id
+      to_columns:
+      - user_id
+  
+  '''
+# ---

--- a/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
+++ b/converters/dbt/tests/__snapshots__/test_osi_to_msi.ambr
@@ -1,0 +1,49 @@
+# serializer version: 1
+# name: TestOSIToMSIRoundTrip.test_osi_to_msi_to_osi_preserves_structure
+  '''
+  version: 0.2.0.dev0
+  dialects:
+  - ANSI_SQL
+  semantic_model:
+  - name: semantic_model
+    datasets:
+    - name: orders
+      source: analytics.orders
+      primary_key:
+      - order_id
+      fields:
+      - name: order_id
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: order_id
+      - name: status
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: status
+        dimension:
+          is_time: false
+      - name: created_at
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: created_at
+        dimension:
+          is_time: true
+      - name: amount
+        expression:
+          dialects:
+          - dialect: ANSI_SQL
+            expression: amount
+        dimension:
+          is_time: false
+    metrics:
+    - name: revenue
+      expression:
+        dialects:
+        - dialect: ANSI_SQL
+          expression: SUM(orders.amount)
+  
+  '''
+# ---


### PR DESCRIPTION
## Summary

The dbt converter test suite previously had 89 passing tests and 5 failures because the expected Syrupy snapshot baseline files were missing from the repository.

This PR adds the missing snapshot files for the MSI-to-OSI conversion and OSI-to-MSI-to-OSI round-trip tests. The snapshots are now version-controlled, so contributors can run the test suite without first generating them locally using `--snapshot-update`.

## Testing

- All 94 dbt converter tests pass.
- All 5 Syrupy snapshots pass.