### PR TITLE
docs(snowflake): clarify output format and link native Ossie semantic-view functions

### DIFF
--- a/converters/snowflake/README.md
+++ b/converters/snowflake/README.md
@@ -51,5 +51,5 @@ Some Ossie concepts (e.g., `ai_context` on relationships) do not have a native c
 
 A dedicated open-source Ossie ↔ semantic-view converter would be a welcome future addition. In the meantime, Snowflake can already read and write Ossie YAML natively, so the round-trip works today:
 
-- `SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSI_YAML` — create a semantic view directly from Ossie YAML (Ossie YAML → semantic view).
-- `SYSTEM$READ_OSI_YAML_FROM_SEMANTIC_VIEW` — export an existing semantic view to Ossie YAML (semantic view → Ossie YAML).
+- [`SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSI_YAML`](https://docs.snowflake.com/en/sql-reference/stored-procedures/system_create_semantic_view_from_osi_yaml) — create a semantic view directly from Ossie YAML (Ossie YAML → semantic view).
+- [`SYSTEM$READ_OSI_YAML_FROM_SEMANTIC_VIEW`](https://docs.snowflake.com/en/sql-reference/functions/system_read_osi_yaml_from_semantic_view) — export an existing semantic view to Ossie YAML (semantic view → Ossie YAML).

--- a/converters/snowflake/README.md
+++ b/converters/snowflake/README.md
@@ -51,5 +51,5 @@ Some Ossie concepts (e.g., `ai_context` on relationships) do not have a native c
 
 A dedicated open-source Ossie ↔ semantic-view converter would be a welcome future addition. In the meantime, Snowflake can already read and write Ossie YAML natively, so the round-trip works today:
 
-- [`SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSI_YAML`](https://docs.snowflake.com/en/sql-reference/stored-procedures/system_create_semantic_view_from_osi_yaml) — create a semantic view directly from Ossie YAML (Ossie YAML → semantic view).
-- [`SYSTEM$READ_OSI_YAML_FROM_SEMANTIC_VIEW`](https://docs.snowflake.com/en/sql-reference/functions/system_read_osi_yaml_from_semantic_view) — export an existing semantic view to Ossie YAML (semantic view → Ossie YAML).
+- [`SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSSIE_YAML`](https://docs.snowflake.com/en/sql-reference/stored-procedures/system_create_semantic_view_from_ossie_yaml) — create a semantic view directly from Ossie YAML (Ossie YAML → semantic view).
+- [`SYSTEM$READ_OSSIE_YAML_FROM_SEMANTIC_VIEW`](https://docs.snowflake.com/en/sql-reference/functions/system_read_ossie_yaml_from_semantic_view) — export an existing semantic view to Ossie YAML (semantic view → Ossie YAML).

--- a/converters/snowflake/README.md
+++ b/converters/snowflake/README.md
@@ -21,6 +21,8 @@
 
 Converts Ossie YAML semantic models to [Snowflake Cortex Analyst](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-analyst) semantic model YAML. Pure offline conversion — no Snowflake connection required.
 
+> **Output format:** This converter produces the **legacy** Cortex Analyst semantic model YAML — the stage-based format. It is *not* the newer Snowflake [semantic view YAML](https://docs.snowflake.com/en/user-guide/views-semantic/semantic-view-yaml-spec) (`views-semantic`) that pairs with the `CREATE SEMANTIC VIEW` DDL. The two structures overlap heavily but are distinct Snowflake surfaces. See [Ossie YAML and Snowflake semantic views](#ossie-yaml-and-snowflake-semantic-views) below for how to get to an actual semantic view.
+
 > **Note:** This converter is under active development. It handles common cases but has not been thoroughly tested against all edge cases — use with caution in production.
 
 ## Setup
@@ -44,3 +46,10 @@ python3 -m pytest tests/
 ## Limitations
 
 Some Ossie concepts (e.g., `ai_context` on relationships) do not have a native counterpart in the Snowflake semantic model. These are dropped during conversion and the converter will emit warnings so you know what was left behind.
+
+## Ossie YAML and Snowflake semantic views
+
+A dedicated open-source Ossie ↔ semantic-view converter would be a welcome future addition. In the meantime, Snowflake can already read and write Ossie YAML natively, so the round-trip works today:
+
+- `SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSI_YAML` — create a semantic view directly from Ossie YAML (Ossie YAML → semantic view).
+- `SYSTEM$READ_OSI_YAML_FROM_SEMANTIC_VIEW` — export an existing semantic view to Ossie YAML (semantic view → Ossie YAML).


### PR DESCRIPTION
## Motivation

The Snowflake converter's README could give the impression that it produces the newer Snowflake *semantic view* YAML (the format paired with `CREATE SEMANTIC VIEW`). It actually emits the legacy Cortex Analyst semantic model YAML (the stage-based format). These structures overlap but are distinct Snowflake surfaces, and the ambiguity could mislead users about what the output can be plugged into.

## Change

Documentation only — no code or test changes.

- Add an **Output format** note clarifying that the converter emits the legacy Cortex Analyst semantic model YAML, not the semantic view YAML, with a link to Snowflake's semantic view YAML spec.
- Add an **"Ossie YAML and Snowflake semantic views"** section pointing to the native Snowflake procedures/functions that round-trip Ossie YAML to and from semantic views today:
  - `SYSTEM$CREATE_SEMANTIC_VIEW_FROM_OSSIE_YAML` (Ossie YAML → semantic view)
  - `SYSTEM$READ_OSSIE_YAML_FROM_SEMANTIC_VIEW` (semantic view → Ossie YAML)

Both are linked to their official docs. The section also flags a dedicated open-source Ossie ↔ semantic-view converter as welcome future work.

## Scope

- Single file changed: `converters/snowflake/README.md`
- No changes to the converter source or tests.
- ASF license header preserved.

## Checklist

- [ ] ICLA on file with the ASF (required before a first non-trivial contribution merges)
- [x] Change is documentation-only; no tests affected
- [x] Motivation and change described above