### PR TITLE
ci(wisdom): add converter test workflow

### DIFF
--- a/.github/workflows/converter-wisdom-ci.yml
+++ b/.github/workflows/converter-wisdom-ci.yml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Converters Wisdom CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'converters/wisdom/**'
+      - '.github/workflows/converter-wisdom-ci.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'converters/wisdom/**'
+      - '.github/workflows/converter-wisdom-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Sync dependencies
+        working-directory: converters/wisdom
+        run: |
+          uv sync
+
+      - name: Unit Tests
+        working-directory: converters/wisdom
+        run: |
+          uv run pytest


### PR DESCRIPTION
## Summary

- Add a dedicated GitHub Actions workflow for the Wisdom converter.
- Run the existing pytest suite on Python 3.11, 3.12, 3.13, and 3.14.
- Limit triggers to `converters/wisdom/**` and the workflow itself.
- Use read-only repository permissions and the pinned Actions already used by the repository.

No converter behavior, Ossie specification, ontology, SDK model, dependency, or lock-file changes are included.

## Related Issues

Closes #273

## Validation

- `git diff --cached --check`: passed before commit.
- Local `uv sync` / `uv run pytest`: not completed. The available system Python is 3.10, below the project's `>=3.11` requirement, and Windows Application Control blocked uv's isolated build-environment Python.
- GitHub Actions Python 3.11-3.14 matrix: pending on this draft PR.

## Compliance

- The new file contains the ASF license header.
- Existing pinned checkout/setup-python Actions and the repository's current uv installation pattern are reused.
- No third-party package dependency is added.
- The commit includes `Signed-off-by`.

## Scope and overlap

Open PRs #222 and #262 modify `converters/wisdom/pyproject.toml` but do not modify this workflow file. The workflow should be revalidated if either PR merges first.

## Risks and rollback

This change affects CI execution only. It can be reverted by removing `.github/workflows/converter-wisdom-ci.yml`.