### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  # GitHub Actions used by all CI workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Go CLI
+  - package-ecosystem: "gomod"
+    directory: "/cli"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+
+  # Python projects (PEP 621 / hatchling)
+  - package-ecosystem: "pip"
+    directories:
+      - "/python"
+      - "/converters/dbt"
+      - "/converters/databricks"
+      - "/converters/gooddata"
+      - "/converters/honeydew"
+      - "/converters/omni"
+      - "/converters/orionbelt"
+      - "/converters/snowflake"
+      - "/converters/wisdom"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # Maven / Java converters
+  - package-ecosystem: "maven"
+    directories:
+      - "/converters/polaris"
+      - "/converters/salesforce"
+    schedule:
+      interval: "weekly"
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency updates across every package ecosystem in the repository:

- **`github-actions`** (`/`) — keeps the CI workflow actions up to date
- **`gomod`** (`/cli`) — the Go CLI
- **`pip`** — all PEP 621 / hatchling Python projects: `/python` plus the converters `dbt`, `databricks`, `gooddata`, `honeydew`, `omni`, `orionbelt`, `snowflake`, and `wisdom`
- **`maven`** — the Java converters `polaris` and `salesforce`

Updates run on a **weekly** schedule and are **grouped per ecosystem** so each ecosystem produces a single consolidated PR rather than one PR per dependency, keeping review noise low for this multi-module repo.

The file carries the standard ASF license header to match the rest of the repo.

## Related Issues

<!-- none -->

## Checklist

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval