### PR TITLE
feat: add extended metadata fields for fields and metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -351,7 +351,7 @@ Ossie standardizes structural and logical semantics well, but there is limited s
 
 **Roadmap Deliverables:**
 
-- [Extended Metadata Proposal for Ossie](https://github.com/apache/ossie/issues/100) — optional, backward-compatible metadata fields (e.g., `measurement`, `display_format`, `semantic_type`, `default_aggregation`, `desired_direction`, `default_sort`, `semantic_mappings`)
+- [Extended Metadata Proposal for Ossie](https://github.com/apache/ossie/issues/100) — optional, backward-compatible metadata fields (e.g., `measurement`, `display_format`, `semantic_type`, `default_aggregation`, `desired_direction`, `default_sort`, `glossary_references`)
 - Richer application-specific extension points beyond `custom_extensions`
 - Sample value annotations for documentation and AI grounding
 

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -124,6 +124,86 @@
       ],
       "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
     },
+    "SemanticType": {
+      "type": "string",
+      "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
+      "description": "High-level semantic classification of a field or metric"
+    },
+    "DesiredDirection": {
+      "type": "string",
+      "enum": ["higher_is_better", "lower_is_better", "neutral"],
+      "description": "KPI polarity indicating whether higher or lower values are preferred"
+    },
+    "DefaultAggregation": {
+      "type": "string",
+      "enum": ["sum", "avg", "min", "max", "count", "count_distinct"],
+      "description": "Default aggregation function to apply when this field is used as a measure"
+    },
+    "DefaultTimeGranularity": {
+      "type": "string",
+      "enum": ["day", "week", "month", "quarter", "year"],
+      "description": "Default time bucket for temporal fields"
+    },
+    "UnitSystem": {
+      "type": "string",
+      "enum": ["si", "imperial", "custom"],
+      "description": "Unit system classification"
+    },
+    "Measurement": {
+      "type": "object",
+      "description": "Describes what a numeric value represents (units and measurement)",
+      "properties": {
+        "quantity_kind": {
+          "type": "string",
+          "description": "The kind of quantity (e.g., currency, length, weight, temperature, percentage, duration)"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Specific unit. For currency use ISO 4217 (e.g., usd, eur). For others use UCUM or descriptive strings."
+        },
+        "unit_system": {
+          "$ref": "#/$defs/UnitSystem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DefaultSort": {
+      "type": "object",
+      "description": "Default sorting behavior",
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": ["asc", "desc"],
+          "description": "Sort direction"
+        },
+        "nulls": {
+          "type": "string",
+          "enum": ["first", "last"],
+          "description": "Null value positioning"
+        },
+        "by_field": {
+          "type": "string",
+          "description": "Sort by a different field (e.g., sort month names by month number)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SemanticMapping": {
+      "type": "object",
+      "description": "Link to an external ontology or standard",
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Ontology or standard name (e.g., schema.org, FIBO)"
+        },
+        "identifier": {
+          "type": "string",
+          "description": "URI or identifier within that ontology"
+        }
+      },
+      "required": ["source", "identifier"],
+      "additionalProperties": false
+    },
     "Dimension": {
       "type": "object",
       "description": "Dimension metadata",
@@ -153,6 +233,10 @@
           "type": "string",
           "description": "Label for categorization"
         },
+        "display_label": {
+          "type": "string",
+          "description": "Human-readable display name for UI and AI interaction"
+        },
         "description": {
           "type": "string",
           "description": "Human-readable description"
@@ -162,6 +246,40 @@
         },
         "ai_context": {
           "$ref": "#/$defs/AIContext"
+        },
+        "semantic_type": {
+          "$ref": "#/$defs/SemanticType"
+        },
+        "measurement": {
+          "$ref": "#/$defs/Measurement"
+        },
+        "display_format": {
+          "type": "string",
+          "description": "Excel-compatible display format string (e.g., $#,##0.00, 0.0%, #,##0)"
+        },
+        "default_aggregation": {
+          "$ref": "#/$defs/DefaultAggregation"
+        },
+        "default_sort": {
+          "$ref": "#/$defs/DefaultSort"
+        },
+        "default_time_granularity": {
+          "$ref": "#/$defs/DefaultTimeGranularity"
+        },
+        "semantic_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SemanticMapping"
+          },
+          "description": "Links to external ontologies or standards"
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Whether this field should be hidden from consumer UIs"
+        },
+        "group_label": {
+          "type": "string",
+          "description": "Organizational grouping label for UI presentation"
         },
         "custom_extensions": {
           "type": "array",
@@ -290,6 +408,41 @@
         },
         "ai_context": {
           "$ref": "#/$defs/AIContext"
+        },
+        "display_label": {
+          "type": "string",
+          "description": "Human-readable display name for UI and AI interaction"
+        },
+        "semantic_type": {
+          "$ref": "#/$defs/SemanticType"
+        },
+        "measurement": {
+          "$ref": "#/$defs/Measurement"
+        },
+        "display_format": {
+          "type": "string",
+          "description": "Excel-compatible display format string (e.g., $#,##0.00, 0.0%, #,##0)"
+        },
+        "desired_direction": {
+          "$ref": "#/$defs/DesiredDirection"
+        },
+        "default_sort": {
+          "$ref": "#/$defs/DefaultSort"
+        },
+        "semantic_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SemanticMapping"
+          },
+          "description": "Links to external ontologies or standards"
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Whether this metric should be hidden from consumer UIs"
+        },
+        "group_label": {
+          "type": "string",
+          "description": "Organizational grouping label for UI presentation"
         },
         "custom_extensions": {
           "type": "array",

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -125,9 +125,19 @@
       "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
     },
     "SemanticType": {
-      "type": "string",
-      "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
-      "description": "High-level semantic classification of a field or metric"
+      "description": "High-level semantic classification of a field or metric. Either a well-known token or a URI pointing to an external type system.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
+          "description": "Well-known semantic type token"
+        },
+        {
+          "type": "string",
+          "format": "uri",
+          "description": "URI pointing to an external type system (e.g., ISO 20022, FIBO, SKOS vocabulary)"
+        }
+      ]
     },
     "DesiredDirection": {
       "type": "string",
@@ -190,18 +200,23 @@
     },
     "SemanticMapping": {
       "type": "object",
-      "description": "Link to an external ontology or standard",
+      "description": "Link to an external ontology or standard using a SKOS-based predicate. The predicate vocabulary is intentionally open to allow non-positive assertions (e.g. DISTINCT_FROM) via extensions.",
       "properties": {
-        "source": {
+        "target": {
           "type": "string",
-          "description": "Ontology or standard name (e.g., schema.org, FIBO)"
+          "format": "uri",
+          "description": "URI of the external concept (e.g., https://schema.org/MonetaryAmount, https://spec.edmcouncil.org/fibo/...)"
         },
-        "identifier": {
+        "predicate": {
           "type": "string",
-          "description": "URI or identifier within that ontology"
+          "description": "Relationship type. SKOS baseline: exactMatch, closeMatch, broadMatch, narrowMatch, relatedMatch. Defaults to exactMatch. Vocabulary is open — non-standard predicates (e.g., DISTINCT_FROM) are permitted."
+        },
+        "provenance": {
+          "type": "string",
+          "description": "Optional: origin of this mapping (e.g., 'manual', 'FIBO 4.1', a tool name)"
         }
       },
-      "required": ["source", "identifier"],
+      "required": ["target"],
       "additionalProperties": false
     },
     "Dimension": {

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -124,6 +124,86 @@
       ],
       "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
     },
+    "SemanticType": {
+      "type": "string",
+      "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
+      "description": "High-level semantic classification of a field or metric"
+    },
+    "DesiredDirection": {
+      "type": "string",
+      "enum": ["higher_is_better", "lower_is_better", "neutral"],
+      "description": "KPI polarity indicating whether higher or lower values are preferred"
+    },
+    "DefaultAggregation": {
+      "type": "string",
+      "enum": ["sum", "avg", "min", "max", "count", "count_distinct"],
+      "description": "Default aggregation function to apply when this field is used as a measure"
+    },
+    "DefaultTimeGranularity": {
+      "type": "string",
+      "enum": ["day", "week", "month", "quarter", "year"],
+      "description": "Default time bucket for temporal fields"
+    },
+    "UnitSystem": {
+      "type": "string",
+      "enum": ["si", "imperial", "custom"],
+      "description": "Unit system classification"
+    },
+    "Measurement": {
+      "type": "object",
+      "description": "Describes what a numeric value represents (units and measurement)",
+      "properties": {
+        "quantity_kind": {
+          "type": "string",
+          "description": "The kind of quantity (e.g., currency, length, weight, temperature, percentage, duration)"
+        },
+        "unit": {
+          "type": "string",
+          "description": "Specific unit. For currency use ISO 4217 (e.g., usd, eur). For others use UCUM or descriptive strings."
+        },
+        "unit_system": {
+          "$ref": "#/$defs/UnitSystem"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DefaultSort": {
+      "type": "object",
+      "description": "Default sorting behavior",
+      "properties": {
+        "direction": {
+          "type": "string",
+          "enum": ["asc", "desc"],
+          "description": "Sort direction"
+        },
+        "nulls": {
+          "type": "string",
+          "enum": ["first", "last"],
+          "description": "Null value positioning"
+        },
+        "by_field": {
+          "type": "string",
+          "description": "Sort by a different field (e.g., sort month names by month number)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SemanticMapping": {
+      "type": "object",
+      "description": "Link to an external ontology or standard",
+      "properties": {
+        "source": {
+          "type": "string",
+          "description": "Ontology or standard name (e.g., schema.org, FIBO)"
+        },
+        "identifier": {
+          "type": "string",
+          "description": "URI or identifier within that ontology"
+        }
+      },
+      "required": ["source", "identifier"],
+      "additionalProperties": false
+    },
     "Dimension": {
       "type": "object",
       "description": "Dimension metadata",
@@ -153,6 +233,10 @@
           "type": "string",
           "description": "Label for categorization"
         },
+        "display_label": {
+          "type": "string",
+          "description": "Human-readable display name for UI and AI interaction"
+        },
         "description": {
           "type": "string",
           "description": "Human-readable description"
@@ -162,6 +246,40 @@
         },
         "ai_context": {
           "$ref": "#/$defs/AIContext"
+        },
+        "semantic_type": {
+          "$ref": "#/$defs/SemanticType"
+        },
+        "measurement": {
+          "$ref": "#/$defs/Measurement"
+        },
+        "display_format": {
+          "type": "string",
+          "description": "Excel-compatible display format string (e.g., $#,##0.00, 0.0%, #,##0)"
+        },
+        "default_aggregation": {
+          "$ref": "#/$defs/DefaultAggregation"
+        },
+        "default_sort": {
+          "$ref": "#/$defs/DefaultSort"
+        },
+        "default_time_granularity": {
+          "$ref": "#/$defs/DefaultTimeGranularity"
+        },
+        "semantic_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SemanticMapping"
+          },
+          "description": "Links to external ontologies or standards"
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Whether this field should be hidden from consumer UIs"
+        },
+        "group_label": {
+          "type": "string",
+          "description": "Organizational grouping label for UI presentation"
         },
         "custom_extensions": {
           "type": "array",
@@ -290,6 +408,41 @@
         },
         "ai_context": {
           "$ref": "#/$defs/AIContext"
+        },
+        "display_label": {
+          "type": "string",
+          "description": "Human-readable display name for UI and AI interaction"
+        },
+        "semantic_type": {
+          "$ref": "#/$defs/SemanticType"
+        },
+        "measurement": {
+          "$ref": "#/$defs/Measurement"
+        },
+        "display_format": {
+          "type": "string",
+          "description": "Excel-compatible display format string (e.g., $#,##0.00, 0.0%, #,##0)"
+        },
+        "desired_direction": {
+          "$ref": "#/$defs/DesiredDirection"
+        },
+        "default_sort": {
+          "$ref": "#/$defs/DefaultSort"
+        },
+        "semantic_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SemanticMapping"
+          },
+          "description": "Links to external ontologies or standards"
+        },
+        "hidden": {
+          "type": "boolean",
+          "description": "Whether this metric should be hidden from consumer UIs"
+        },
+        "group_label": {
+          "type": "string",
+          "description": "Organizational grouping label for UI presentation"
         },
         "custom_extensions": {
           "type": "array",

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -125,9 +125,19 @@
       "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
     },
     "SemanticType": {
-      "type": "string",
-      "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
-      "description": "High-level semantic classification of a field or metric"
+      "description": "High-level semantic classification of a field or metric. Either a well-known token or a URI pointing to an external type system.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
+          "description": "Well-known semantic type token"
+        },
+        {
+          "type": "string",
+          "format": "uri",
+          "description": "URI pointing to an external type system (e.g., ISO 20022, FIBO, SKOS vocabulary)"
+        }
+      ]
     },
     "DesiredDirection": {
       "type": "string",
@@ -190,18 +200,23 @@
     },
     "SemanticMapping": {
       "type": "object",
-      "description": "Link to an external ontology or standard",
+      "description": "Link to an external ontology or standard using a SKOS-based predicate. The predicate vocabulary is intentionally open to allow non-positive assertions (e.g. DISTINCT_FROM) via extensions.",
       "properties": {
-        "source": {
+        "target": {
           "type": "string",
-          "description": "Ontology or standard name (e.g., schema.org, FIBO)"
+          "format": "uri",
+          "description": "URI of the external concept (e.g., https://schema.org/MonetaryAmount, https://spec.edmcouncil.org/fibo/...)"
         },
-        "identifier": {
+        "predicate": {
           "type": "string",
-          "description": "URI or identifier within that ontology"
+          "description": "Relationship type. SKOS baseline: exactMatch, closeMatch, broadMatch, narrowMatch, relatedMatch. Defaults to exactMatch. Vocabulary is open — non-standard predicates (e.g., DISTINCT_FROM) are permitted."
+        },
+        "provenance": {
+          "type": "string",
+          "description": "Optional: origin of this mapping (e.g., 'manual', 'FIBO 4.1', a tool name)"
         }
       },
-      "required": ["source", "identifier"],
+      "required": ["target"],
       "additionalProperties": false
     },
     "Dimension": {

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -198,9 +198,9 @@
       },
       "additionalProperties": false
     },
-    "SemanticMapping": {
+    "GlossaryReference": {
       "type": "object",
-      "description": "Link to an external ontology or standard using a SKOS-based predicate. The predicate vocabulary is intentionally open to allow non-positive assertions (e.g. DISTINCT_FROM) via extensions.",
+      "description": "Reference to a concept in an external glossary, ontology, or standard, using a SKOS-based predicate. The predicate vocabulary is intentionally open to allow non-positive assertions (e.g. DISTINCT_FROM) via extensions.",
       "properties": {
         "target": {
           "type": "string",
@@ -213,7 +213,7 @@
         },
         "provenance": {
           "type": "string",
-          "description": "Optional: origin of this mapping (e.g., 'manual', 'FIBO 4.1', a tool name)"
+          "description": "Optional: origin of this reference (e.g., 'manual', 'FIBO 4.1', a tool name)"
         }
       },
       "required": ["target"],
@@ -281,12 +281,12 @@
         "default_time_granularity": {
           "$ref": "#/$defs/DefaultTimeGranularity"
         },
-        "semantic_mappings": {
+        "glossary_references": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/SemanticMapping"
+            "$ref": "#/$defs/GlossaryReference"
           },
-          "description": "Links to external ontologies or standards"
+          "description": "References to concepts in external glossaries, ontologies, or standards"
         },
         "hidden": {
           "type": "boolean",
@@ -447,12 +447,12 @@
         "default_sort": {
           "$ref": "#/$defs/DefaultSort"
         },
-        "semantic_mappings": {
+        "glossary_references": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/SemanticMapping"
+            "$ref": "#/$defs/GlossaryReference"
           },
-          "description": "Links to external ontologies or standards"
+          "description": "References to concepts in external glossaries, ontologies, or standards"
         },
         "hidden": {
           "type": "boolean",

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -125,8 +125,8 @@
       "description": "Logical data type for fields and metrics, independent of role (e.g. dimension vs fact) and physical representation. `Decimal` is exact base-10 with unspecified precision and scale; `Float` is approximate. `DateTime` has no timezone or offset, while `DateTimeTz` identifies an instant using offset or timezone context but does not guarantee preservation of a named timezone. Omit `datatype` when unknown; use `Opaque` plus `custom_extensions` for a known type outside the portable vocabulary."
     },
     "SemanticType": {
-      "description": "High-level semantic classification of a field or metric. Either a well-known token or a URI pointing to an external type system.",
-      "oneOf": [
+      "description": "High-level semantic classification of a field or metric. Either a well-known token or an absolute URI pointing to an external type system.",
+      "anyOf": [
         {
           "type": "string",
           "enum": ["categorical", "quantitative", "monetary", "temporal", "geographic", "ordinal", "identifier"],
@@ -134,8 +134,8 @@
         },
         {
           "type": "string",
-          "format": "uri",
-          "description": "URI pointing to an external type system (e.g., ISO 20022, FIBO, SKOS vocabulary)"
+          "pattern": "^[A-Za-z][A-Za-z0-9+.-]*:",
+          "description": "Absolute URI pointing to an external type system (e.g., ISO 20022, FIBO, a SKOS vocabulary). Must include a scheme, e.g. https://www.iso20022.org/glossary/LEI. The scheme requirement keeps this branch disjoint from the token branch, so a misspelled token is rejected rather than silently accepted as a URI."
         }
       ]
     },

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -292,9 +292,12 @@
           "type": "boolean",
           "description": "Whether this field should be hidden from consumer UIs"
         },
-        "group_label": {
-          "type": "string",
-          "description": "Organizational grouping label for UI presentation"
+        "group_labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Organizational grouping labels for UI presentation. A field may belong to more than one group."
         },
         "custom_extensions": {
           "type": "array",
@@ -455,9 +458,12 @@
           "type": "boolean",
           "description": "Whether this metric should be hidden from consumer UIs"
         },
-        "group_label": {
-          "type": "string",
-          "description": "Organizational grouping label for UI presentation"
+        "group_labels": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Organizational grouping labels for UI presentation. A field may belong to more than one group."
         },
         "custom_extensions": {
           "type": "array",

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -442,7 +442,9 @@ The following types are used by the extended metadata fields on both fields and 
 
 ### Semantic Type
 
-High-level classification of a field or metric value.
+High-level classification of a field or metric value. Accepts either a **well-known token** or a **URI** pointing to an external type system. Using URIs keeps the field registry-agnostic and allows governed external type systems to carry the long tail of domain-specific types.
+
+**Well-known tokens:**
 
 | Value | Description |
 |-------|-------------|
@@ -453,6 +455,14 @@ High-level classification of a field or metric value.
 | `geographic` | Location-related values (country, lat/lng, region) |
 | `ordinal` | Ordered categorical values (e.g., Low/Medium/High, ratings) |
 | `identifier` | Unique identifiers (e.g., IDs, codes) |
+
+**URI examples** (for regulated or domain-specific types):
+
+```yaml
+semantic_type: https://www.iso20022.org/glossary/LEI
+semantic_type: https://fpml.org/types/ISIN
+semantic_type: https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/UPI
+```
 
 ### Measurement
 
@@ -493,19 +503,43 @@ default_sort:
 
 ### Semantic Mappings
 
-Links a field or metric to external ontologies or standards. Enables semantic interoperability and knowledge graph integration.
+Links a field or metric to external ontologies or standards using a SKOS-based predicate. The predicate vocabulary is **intentionally open** — the SKOS predicates provide a well-understood baseline, but non-standard predicates (e.g., `DISTINCT_FROM` for regulatory disambiguation) are permitted and can be expressed via extensions without being schema-invalid.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `source` | string | Yes | Ontology or standard name (e.g., `schema.org`, `FIBO`) |
-| `identifier` | string | Yes | URI or identifier within that ontology |
+| `target` | string (URI) | Yes | URI of the external concept |
+| `predicate` | string | No | Relationship type. Defaults to `exactMatch`. SKOS baseline predicates listed below. Vocabulary is open. |
+| `provenance` | string | No | Origin of this mapping (e.g., `"manual"`, `"FIBO 4.1"`, a tool name) |
 
-**Example:**
+**SKOS baseline predicates:**
+
+| Predicate | Meaning |
+|-----------|--------|
+| `exactMatch` | Concepts are sufficiently similar to be used interchangeably (default) |
+| `closeMatch` | Concepts are similar enough to be useful in some contexts |
+| `broadMatch` | Target concept is broader (more general) |
+| `narrowMatch` | Target concept is narrower (more specific) |
+| `relatedMatch` | Concepts are associatively related |
+
+**Example — standard alignment:**
 
 ```yaml
 semantic_mappings:
-  - source: schema.org
-    identifier: https://schema.org/MonetaryAmount
+  - target: https://schema.org/MonetaryAmount
+    predicate: exactMatch
+    provenance: manual
+```
+
+**Example — regulatory disambiguation (open predicate):**
+
+```yaml
+semantic_mappings:
+  - target: https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/Counterparty
+    predicate: exactMatch
+    provenance: FIBO 4.1
+  - target: https://www.esma.europa.eu/emir/Counterparty
+    predicate: DISTINCT_FROM
+    provenance: EMIR-vs-MiFIR mapping review 2024
 ```
 
 ### Display Format
@@ -546,8 +580,8 @@ The `display_format` string follows Excel-compatible custom number format conven
     direction: desc
     nulls: last
   semantic_mappings:
-    - source: schema.org
-      identifier: https://schema.org/MonetaryAmount
+    - target: https://schema.org/MonetaryAmount
+      predicate: exactMatch
   group_label: "Revenue"
 ```
 
@@ -570,6 +604,9 @@ The `display_format` string follows Excel-compatible custom number format conven
   default_sort:
     direction: desc
   group_label: "Revenue"
+  semantic_mappings:
+    - target: https://schema.org/MonetaryAmount
+      predicate: exactMatch
 ```
 
 **Temporal field with time granularity:**

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -234,9 +234,19 @@ Fields represent row-level attributes that can be used for grouping, filtering, 
 | `expression` | object | Yes | Expression definition with dialect support |
 | `dimension` | object | No | Dimension metadata (e.g., `is_time` flag) |
 | `label` | string | No | Label for categorization |
+| `display_label` | string | No | Human-readable display name for UI and AI interaction |
 | `description` | string | No | Human-readable description |
 | `datatype` | string (enum) | No | Logical data type for this field. See [Data types](#data-types). |
 | `ai_context` | string/object | No | Additional context for AI tools (e.g., synonyms) |
+| `semantic_type` | string | No | High-level semantic classification (see [Semantic Type](#semantic-type)) |
+| `measurement` | object | No | Unit and quantity metadata (see [Measurement](#measurement)) |
+| `display_format` | string | No | Excel-compatible format string (e.g., `$#,##0.00`, `0.0%`) |
+| `default_aggregation` | string | No | Default aggregation when used as a measure: `sum`, `avg`, `min`, `max`, `count`, `count_distinct` |
+| `default_sort` | object | No | Default sorting behavior (see [Default Sort](#default-sort)) |
+| `default_time_granularity` | string | No | Default time bucket for temporal fields: `day`, `week`, `month`, `quarter`, `year` |
+| `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
+| `hidden` | boolean | No | Whether this field should be hidden from consumer UIs |
+| `group_label` | string | No | Organizational grouping label for UI presentation |
 | `custom_extensions` | array | No | Vendor-specific attributes |
 
 ### Expression Object
@@ -369,6 +379,15 @@ Quantitative measures defined on business data, representing key calculations li
 | `description` | string | No | Human-readable description of what the metric measures |
 | `datatype` | string (enum) | No | Logical data type for this metric. See [Data types](#data-types). |
 | `ai_context` | string/object | No | Additional context for AI tools (e.g., synonyms) |
+| `display_label` | string | No | Human-readable display name for UI and AI interaction |
+| `semantic_type` | string | No | High-level semantic classification (see [Semantic Type](#semantic-type)) |
+| `measurement` | object | No | Unit and quantity metadata (see [Measurement](#measurement)) |
+| `display_format` | string | No | Excel-compatible format string (e.g., `$#,##0.00`, `0.0%`) |
+| `desired_direction` | string | No | KPI polarity: `higher_is_better`, `lower_is_better`, `neutral` |
+| `default_sort` | object | No | Default sorting behavior (see [Default Sort](#default-sort)) |
+| `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
+| `hidden` | boolean | No | Whether this metric should be hidden from consumer UIs |
+| `group_label` | string | No | Organizational grouping label for UI presentation |
 | `custom_extensions` | array | No | Vendor-specific attributes |
 
 ### Expression Object
@@ -413,6 +432,173 @@ expression:
   ai_context:
     synonyms:
       - "Order Average by customer"
+```
+
+---
+
+## Extended Metadata Types
+
+The following types are used by the extended metadata fields on both fields and metrics. All extended metadata is **optional** and **non-executional** — it does not affect query execution but enables consumers (BI tools, AI agents, developers) to correctly interpret, render, and present data.
+
+### Semantic Type
+
+High-level classification of a field or metric value.
+
+| Value | Description |
+|-------|-------------|
+| `categorical` | Unordered categorical values (e.g., status, color) |
+| `quantitative` | Numeric values representing quantities |
+| `monetary` | Currency/financial values |
+| `temporal` | Time or date values |
+| `geographic` | Location-related values (country, lat/lng, region) |
+| `ordinal` | Ordered categorical values (e.g., Low/Medium/High, ratings) |
+| `identifier` | Unique identifiers (e.g., IDs, codes) |
+
+### Measurement
+
+Describes what a numeric value represents. Enables unit-aware reasoning and formatting.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `quantity_kind` | string | The kind of quantity (e.g., `currency`, `length`, `weight`, `temperature`, `percentage`, `duration`) |
+| `unit` | string | Specific unit. For currency, use ISO 4217 codes (e.g., `usd`, `eur`, `gbp`). For others, use UCUM or descriptive strings (e.g., `meters`, `kg`, `celsius`) |
+| `unit_system` | string | Unit system: `si`, `imperial`, `custom` |
+
+**Example:**
+
+```yaml
+measurement:
+  quantity_kind: currency
+  unit: usd
+  unit_system: custom
+```
+
+### Default Sort
+
+Defines default sorting behavior for a field or metric.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `direction` | string | Sort direction: `asc`, `desc` |
+| `nulls` | string | Null positioning: `first`, `last` |
+| `by_field` | string | Sort by a different field (e.g., sort month names by month number) |
+
+**Example:**
+
+```yaml
+default_sort:
+  direction: desc
+  nulls: last
+```
+
+### Semantic Mappings
+
+Links a field or metric to external ontologies or standards. Enables semantic interoperability and knowledge graph integration.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | string | Yes | Ontology or standard name (e.g., `schema.org`, `FIBO`) |
+| `identifier` | string | Yes | URI or identifier within that ontology |
+
+**Example:**
+
+```yaml
+semantic_mappings:
+  - source: schema.org
+    identifier: https://schema.org/MonetaryAmount
+```
+
+### Display Format
+
+The `display_format` string follows Excel-compatible custom number format conventions. Consumers MAY support a subset, but interoperability is improved when adhering to common patterns.
+
+**Common Patterns:**
+
+| Pattern | Description | Example Output |
+|---------|-------------|----------------|
+| `$#,##0.00` | Currency with 2 decimals | $1,234.56 |
+| `#,##0` | Integer with grouping | 12,345 |
+| `0.0%` | Percentage with 1 decimal | 12.3% |
+| `#,##0.00;(#,##0.00)` | Positive/negative | 1,234.56 or (1,234.56) |
+| `0.00E+00` | Scientific notation | 1.23E+04 |
+| `yyyy-mm-dd` | Date format | 2024-01-15 |
+
+---
+
+## Extended Metadata Examples
+
+**Field with full extended metadata:**
+
+```yaml
+- name: sales_amount
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: sales_amount
+  display_label: "Sales Amount"
+  semantic_type: monetary
+  measurement:
+    quantity_kind: currency
+    unit: usd
+  display_format: "$#,##0.00"
+  default_aggregation: sum
+  default_sort:
+    direction: desc
+    nulls: last
+  semantic_mappings:
+    - source: schema.org
+      identifier: https://schema.org/MonetaryAmount
+  group_label: "Revenue"
+```
+
+**Metric with extended metadata:**
+
+```yaml
+- name: total_sales
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: SUM(orders.sales_amount)
+  display_label: "Total Sales"
+  description: Total revenue from all completed orders
+  semantic_type: monetary
+  measurement:
+    quantity_kind: currency
+    unit: usd
+  display_format: "$#,##0.00"
+  desired_direction: higher_is_better
+  default_sort:
+    direction: desc
+  group_label: "Revenue"
+```
+
+**Temporal field with time granularity:**
+
+```yaml
+- name: order_date
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: order_date
+  dimension:
+    is_time: true
+  display_label: "Order Date"
+  semantic_type: temporal
+  default_time_granularity: month
+  default_sort:
+    direction: desc
+```
+
+**Hidden field used only in expressions:**
+
+```yaml
+- name: internal_cost_basis
+  expression:
+    dialects:
+      - dialect: ANSI_SQL
+        expression: raw_cost * adjustment_factor
+  hidden: true
+  description: Internal cost calculation used by margin metrics
 ```
 
 ---

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -246,7 +246,7 @@ Fields represent row-level attributes that can be used for grouping, filtering, 
 | `default_time_granularity` | string | No | Default time bucket for temporal fields: `day`, `week`, `month`, `quarter`, `year` |
 | `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
 | `hidden` | boolean | No | Whether this field should be hidden from consumer UIs |
-| `group_label` | string | No | Organizational grouping label for UI presentation |
+| `group_labels` | array of strings | No | Organizational grouping labels for UI presentation. A field may belong to more than one group. |
 | `custom_extensions` | array | No | Vendor-specific attributes |
 
 ### Expression Object
@@ -387,7 +387,7 @@ Quantitative measures defined on business data, representing key calculations li
 | `default_sort` | object | No | Default sorting behavior (see [Default Sort](#default-sort)) |
 | `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
 | `hidden` | boolean | No | Whether this metric should be hidden from consumer UIs |
-| `group_label` | string | No | Organizational grouping label for UI presentation |
+| `group_labels` | array of strings | No | Organizational grouping labels for UI presentation. A field may belong to more than one group. |
 | `custom_extensions` | array | No | Vendor-specific attributes |
 
 ### Expression Object
@@ -582,7 +582,9 @@ The `display_format` string follows Excel-compatible custom number format conven
   semantic_mappings:
     - target: https://schema.org/MonetaryAmount
       predicate: exactMatch
-  group_label: "Revenue"
+  group_labels:
+    - "Revenue"
+    - "Financial Metrics"
 ```
 
 **Metric with extended metadata:**
@@ -603,7 +605,9 @@ The `display_format` string follows Excel-compatible custom number format conven
   desired_direction: higher_is_better
   default_sort:
     direction: desc
-  group_label: "Revenue"
+  group_labels:
+    - "Revenue"
+    - "Financial Metrics"
   semantic_mappings:
     - target: https://schema.org/MonetaryAmount
       predicate: exactMatch

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -442,7 +442,7 @@ The following types are used by the extended metadata fields on both fields and 
 
 ### Semantic Type
 
-High-level classification of a field or metric value. Accepts either a **well-known token** or a **URI** pointing to an external type system. Using URIs keeps the field registry-agnostic and allows governed external type systems to carry the long tail of domain-specific types.
+High-level classification of a field or metric value. Accepts either a **well-known token** or an **absolute URI** pointing to an external type system. Using URIs keeps the field registry-agnostic and allows governed external type systems to carry the long tail of domain-specific types.
 
 **Well-known tokens:**
 
@@ -463,6 +463,8 @@ semantic_type: https://www.iso20022.org/glossary/LEI
 semantic_type: https://fpml.org/types/ISIN
 semantic_type: https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/UPI
 ```
+
+A URI value MUST include a scheme (for example `https:` or `urn:`). This keeps the URI form distinguishable from the token form, so a value that is neither a well-known token nor a scheme-qualified URI — such as a misspelled `monetory` — is rejected rather than silently accepted as an opaque type reference.
 
 ### Measurement
 

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -244,7 +244,7 @@ Fields represent row-level attributes that can be used for grouping, filtering, 
 | `default_aggregation` | string | No | Default aggregation when used as a measure: `sum`, `avg`, `min`, `max`, `count`, `count_distinct` |
 | `default_sort` | object | No | Default sorting behavior (see [Default Sort](#default-sort)) |
 | `default_time_granularity` | string | No | Default time bucket for temporal fields: `day`, `week`, `month`, `quarter`, `year` |
-| `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
+| `glossary_references` | array | No | References to concepts in external glossaries or ontologies (see [Glossary References](#glossary-references)) |
 | `hidden` | boolean | No | Whether this field should be hidden from consumer UIs |
 | `group_labels` | array of strings | No | Organizational grouping labels for UI presentation. A field may belong to more than one group. |
 | `custom_extensions` | array | No | Vendor-specific attributes |
@@ -385,7 +385,7 @@ Quantitative measures defined on business data, representing key calculations li
 | `display_format` | string | No | Excel-compatible format string (e.g., `$#,##0.00`, `0.0%`) |
 | `desired_direction` | string | No | KPI polarity: `higher_is_better`, `lower_is_better`, `neutral` |
 | `default_sort` | object | No | Default sorting behavior (see [Default Sort](#default-sort)) |
-| `semantic_mappings` | array | No | Links to external ontologies (see [Semantic Mappings](#semantic-mappings)) |
+| `glossary_references` | array | No | References to concepts in external glossaries or ontologies (see [Glossary References](#glossary-references)) |
 | `hidden` | boolean | No | Whether this metric should be hidden from consumer UIs |
 | `group_labels` | array of strings | No | Organizational grouping labels for UI presentation. A field may belong to more than one group. |
 | `custom_extensions` | array | No | Vendor-specific attributes |
@@ -503,15 +503,15 @@ default_sort:
   nulls: last
 ```
 
-### Semantic Mappings
+### Glossary References
 
-Links a field or metric to external ontologies or standards using a SKOS-based predicate. The predicate vocabulary is **intentionally open** — the SKOS predicates provide a well-understood baseline, but non-standard predicates (e.g., `DISTINCT_FROM` for regulatory disambiguation) are permitted and can be expressed via extensions without being schema-invalid.
+References a field or metric to concepts in an external glossary, ontology, or standard using a SKOS-based predicate. The predicate vocabulary is **intentionally open** — the SKOS predicates provide a well-understood baseline, but non-standard predicates (e.g., `DISTINCT_FROM` for regulatory disambiguation) are permitted and can be expressed via extensions without being schema-invalid.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `target` | string (URI) | Yes | URI of the external concept |
 | `predicate` | string | No | Relationship type. Defaults to `exactMatch`. SKOS baseline predicates listed below. Vocabulary is open. |
-| `provenance` | string | No | Origin of this mapping (e.g., `"manual"`, `"FIBO 4.1"`, a tool name) |
+| `provenance` | string | No | Origin of this reference (e.g., `"manual"`, `"FIBO 4.1"`, a tool name) |
 
 **SKOS baseline predicates:**
 
@@ -526,7 +526,7 @@ Links a field or metric to external ontologies or standards using a SKOS-based p
 **Example — standard alignment:**
 
 ```yaml
-semantic_mappings:
+glossary_references:
   - target: https://schema.org/MonetaryAmount
     predicate: exactMatch
     provenance: manual
@@ -535,13 +535,13 @@ semantic_mappings:
 **Example — regulatory disambiguation (open predicate):**
 
 ```yaml
-semantic_mappings:
+glossary_references:
   - target: https://spec.edmcouncil.org/fibo/ontology/DER/RateDerivatives/IRSwaps/Counterparty
     predicate: exactMatch
     provenance: FIBO 4.1
   - target: https://www.esma.europa.eu/emir/Counterparty
     predicate: DISTINCT_FROM
-    provenance: EMIR-vs-MiFIR mapping review 2024
+    provenance: EMIR-vs-MiFIR review 2024
 ```
 
 ### Display Format
@@ -581,7 +581,7 @@ The `display_format` string follows Excel-compatible custom number format conven
   default_sort:
     direction: desc
     nulls: last
-  semantic_mappings:
+  glossary_references:
     - target: https://schema.org/MonetaryAmount
       predicate: exactMatch
   group_labels:
@@ -610,7 +610,7 @@ The `display_format` string follows Excel-compatible custom number format conven
   group_labels:
     - "Revenue"
     - "Financial Metrics"
-  semantic_mappings:
+  glossary_references:
     - target: https://schema.org/MonetaryAmount
       predicate: exactMatch
 ```

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -232,7 +232,9 @@ fields:
 
     # Optional: High-level semantic classification of the field
     # Helps consumers determine appropriate visualization and handling
-    # Values: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
+    # Either a well-known token OR a URI pointing to an external type system
+    # Well-known tokens: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
+    # URI examples: https://www.iso20022.org/glossary/LEI, https://fpml.org/types/ISIN
     semantic_type: string
 
     # Optional: Describes what a numeric value represents (units and measurement)
@@ -277,9 +279,13 @@ fields:
     default_time_granularity: string
 
     # Optional: Links to external ontologies or standards
+    # Uses SKOS-based predicates as a baseline but the predicate vocabulary is open,
+    # allowing extensions to express non-positive assertions (e.g., DISTINCT_FROM)
     semantic_mappings:
-      - source: string      # Ontology or standard name (e.g., "schema.org", "FIBO")
-        identifier: string  # URI or identifier within that ontology
+      - target: string      # URI of the external concept (e.g., https://schema.org/MonetaryAmount)
+        predicate: string   # Relationship type. SKOS baseline: exactMatch, closeMatch, broadMatch,
+                            # narrowMatch, relatedMatch. Defaults to exactMatch. Vocabulary is open.
+        provenance: string  # Optional: source of this mapping (e.g., "manual", "FIBO 4.1", a tool name)
 
     # Optional: Whether this field should be hidden from consumer UIs
     # Hidden fields remain available for expressions but are not surfaced to end users
@@ -330,7 +336,8 @@ metrics:
     display_label: string
 
     # Optional: High-level semantic classification of the metric
-    # Values: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
+    # Either a well-known token OR a URI pointing to an external type system
+    # Well-known tokens: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
     semantic_type: string
 
     # Optional: Describes what the metric value represents (units and measurement)
@@ -353,9 +360,11 @@ metrics:
       nulls: string      # first, last
 
     # Optional: Links to external ontologies or standards
+    # Uses SKOS-based predicates as a baseline but the predicate vocabulary is open
     semantic_mappings:
-      - source: string
-        identifier: string
+      - target: string      # URI of the external concept
+        predicate: string   # Relationship type (SKOS baseline, open vocabulary). Default: exactMatch
+        provenance: string  # Optional: source of this mapping
 
     # Optional: Whether this metric should be hidden from consumer UIs
     hidden: boolean

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -211,6 +211,10 @@ fields:
     # Optional: Label for categorization (e.g., "filter")
     label: string
 
+    # Optional: Human-readable display name for UI and AI interaction
+    # Provides a user-friendly name distinct from the technical field name
+    display_label: string
+
     # Optional: Human-readable description of the field
     description: string
 
@@ -225,6 +229,65 @@ fields:
     # Optional: Additional context for AI tools (e.g., synonyms, business terms)
     # Helps LLMs understand the field meaning and generate better queries
     ai_context: string
+
+    # Optional: High-level semantic classification of the field
+    # Helps consumers determine appropriate visualization and handling
+    # Values: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
+    semantic_type: string
+
+    # Optional: Describes what a numeric value represents (units and measurement)
+    # Enables unit-aware reasoning and formatting
+    measurement:
+      # Optional: The kind of quantity being measured
+      # Examples: currency, length, weight, temperature, percentage, duration
+      quantity_kind: string
+      # Optional: The specific unit of measurement
+      # For currency, use ISO 4217 codes (e.g., usd, eur, gbp)
+      # For other units, use UCUM or descriptive strings (e.g., meters, kg, celsius)
+      unit: string
+      # Optional: The unit system
+      # Values: si, imperial, custom
+      unit_system: string
+
+    # Optional: Display format string for presentation
+    # Uses Excel-compatible custom number format conventions
+    # Examples: "$#,##0.00", "0.0%", "#,##0", "yyyy-mm-dd"
+    # Consumers MAY fall back to default formatting if unsupported
+    display_format: string
+
+    # Optional: Default aggregation behavior when this field is used as a measure
+    # Removes ambiguity in query generation for consumers
+    # Values: sum, avg, min, max, count, count_distinct
+    default_aggregation: string
+
+    # Optional: Default sorting behavior for this field
+    default_sort:
+      # Optional: Sort direction
+      # Values: asc, desc
+      direction: string
+      # Optional: Null handling
+      # Values: first, last
+      nulls: string
+      # Optional: Sort by a different field (e.g., sort month names by month number)
+      by_field: string
+
+    # Optional: Default time granularity for temporal fields
+    # Only applicable when dimension.is_time is true
+    # Values: day, week, month, quarter, year
+    default_time_granularity: string
+
+    # Optional: Links to external ontologies or standards
+    semantic_mappings:
+      - source: string      # Ontology or standard name (e.g., "schema.org", "FIBO")
+        identifier: string  # URI or identifier within that ontology
+
+    # Optional: Whether this field should be hidden from consumer UIs
+    # Hidden fields remain available for expressions but are not surfaced to end users
+    hidden: boolean
+
+    # Optional: Organizational grouping label for UI presentation
+    # Used to organize fields into logical folders or categories
+    group_label: string
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
@@ -262,6 +325,43 @@ metrics:
     # Optional: Additional context for AI tools (e.g., synonyms, business context)
     # Helps LLMs understand the metric meaning and suggest it appropriately
     ai_context: string
+
+    # Optional: Human-readable display name for UI and AI interaction
+    display_label: string
+
+    # Optional: High-level semantic classification of the metric
+    # Values: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
+    semantic_type: string
+
+    # Optional: Describes what the metric value represents (units and measurement)
+    measurement:
+      quantity_kind: string
+      unit: string
+      unit_system: string
+
+    # Optional: Display format string for presentation
+    # Uses Excel-compatible custom number format conventions
+    display_format: string
+
+    # Optional: Indicates KPI polarity for scorecards and AI summarization
+    # Values: higher_is_better, lower_is_better, neutral
+    desired_direction: string
+
+    # Optional: Default sorting behavior for this metric
+    default_sort:
+      direction: string  # asc, desc
+      nulls: string      # first, last
+
+    # Optional: Links to external ontologies or standards
+    semantic_mappings:
+      - source: string
+        identifier: string
+
+    # Optional: Whether this metric should be hidden from consumer UIs
+    hidden: boolean
+
+    # Optional: Organizational grouping label for UI presentation
+    group_label: string
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -279,14 +279,14 @@ fields:
     # Values: day, week, month, quarter, year
     default_time_granularity: string
 
-    # Optional: Links to external ontologies or standards
+    # Optional: References to external glossaries, ontologies, or standards
     # Uses SKOS-based predicates as a baseline but the predicate vocabulary is open,
     # allowing extensions to express non-positive assertions (e.g., DISTINCT_FROM)
-    semantic_mappings:
+    glossary_references:
       - target: string      # URI of the external concept (e.g., https://schema.org/MonetaryAmount)
         predicate: string   # Relationship type. SKOS baseline: exactMatch, closeMatch, broadMatch,
                             # narrowMatch, relatedMatch. Defaults to exactMatch. Vocabulary is open.
-        provenance: string  # Optional: source of this mapping (e.g., "manual", "FIBO 4.1", a tool name)
+        provenance: string  # Optional: source of this reference (e.g., "manual", "FIBO 4.1", a tool name)
 
     # Optional: Whether this field should be hidden from consumer UIs
     # Hidden fields remain available for expressions but are not surfaced to end users
@@ -363,12 +363,12 @@ metrics:
       direction: string  # asc, desc
       nulls: string      # first, last
 
-    # Optional: Links to external ontologies or standards
+    # Optional: References to external glossaries, ontologies, or standards
     # Uses SKOS-based predicates as a baseline but the predicate vocabulary is open
-    semantic_mappings:
+    glossary_references:
       - target: string      # URI of the external concept
         predicate: string   # Relationship type (SKOS baseline, open vocabulary). Default: exactMatch
-        provenance: string  # Optional: source of this mapping
+        provenance: string  # Optional: source of this reference
 
     # Optional: Whether this metric should be hidden from consumer UIs
     hidden: boolean

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -232,7 +232,8 @@ fields:
 
     # Optional: High-level semantic classification of the field
     # Helps consumers determine appropriate visualization and handling
-    # Either a well-known token OR a URI pointing to an external type system
+    # Either a well-known token OR an absolute URI (scheme required) pointing to
+    # an external type system
     # Well-known tokens: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
     # URI examples: https://www.iso20022.org/glossary/LEI, https://fpml.org/types/ISIN
     semantic_type: string
@@ -338,7 +339,8 @@ metrics:
     display_label: string
 
     # Optional: High-level semantic classification of the metric
-    # Either a well-known token OR a URI pointing to an external type system
+    # Either a well-known token OR an absolute URI (scheme required) pointing to
+    # an external type system
     # Well-known tokens: categorical, quantitative, monetary, temporal, geographic, ordinal, identifier
     semantic_type: string
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -291,9 +291,11 @@ fields:
     # Hidden fields remain available for expressions but are not surfaced to end users
     hidden: boolean
 
-    # Optional: Organizational grouping label for UI presentation
+    # Optional: Organizational grouping labels for UI presentation
     # Used to organize fields into logical folders or categories
-    group_label: string
+    # A field may belong to more than one group
+    group_labels:
+      - string  # e.g., "Revenue", "Financial Metrics"
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
@@ -369,8 +371,10 @@ metrics:
     # Optional: Whether this metric should be hidden from consumer UIs
     hidden: boolean
 
-    # Optional: Organizational grouping label for UI presentation
-    group_label: string
+    # Optional: Organizational grouping labels for UI presentation
+    # A metric may belong to more than one group
+    group_labels:
+      - string  # e.g., "Revenue", "Financial Metrics"
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:


### PR DESCRIPTION
## Summary

This PR proposes a new **extended metadata** layer for the Apache Ossie core spec — a standardized, optional set of non-executional, interpretability metadata fields for `fields` and `metrics`.

A companion announcement and discussion will be sent to `dev@ossie.apache.org`.

### Motivation

OSI/Ossie defines *what data is*. There is currently limited standardization for *how data should be interpreted and presented*. As a result, consumers (BI tools, AI agents, developers) must repeatedly infer or redefine units, display conventions, aggregation behavior, KPI polarity, and field visibility.

This proposal addresses those gaps through optional metadata that does not affect query execution.

**Extended proposal document** (design rationale, field-by-field detail, open questions): https://docs.google.com/document/d/1DLuteF0WwlVbpD5kmHhcqa6vItqNFL4MoAQrImy6dKo

### Changes

Three files in `core-spec/` are updated:

- **`spec.yaml`** — adds extended metadata fields to `fields` and `metrics`
- **`osi-schema.json`** — adds new `$defs`: `SemanticType`, `Measurement`, `DefaultSort`, `SemanticMapping`, `DesiredDirection`, `DefaultAggregation`, `DefaultTimeGranularity`, `UnitSystem`
- **`spec.md`** — documents all new fields with tables, type descriptions, and examples

### New fields

| Field | Applies to | Purpose |
|-------|-----------|---------|
| `display_label` | fields, metrics | Human-readable display name |
| `semantic_type` | fields, metrics | Token or URI classification (e.g., `monetary`, or `https://www.iso20022.org/glossary/LEI`) |
| `measurement` | fields, metrics | Unit/quantity metadata (`quantity_kind`, `unit` ISO 4217, `unit_system`) |
| `display_format` | fields, metrics | Excel-compatible format string (e.g., `$#,##0.00`) |
| `default_sort` | fields, metrics | Default sort direction, null handling, and optional sort-by-field |
| `glossary_references` | fields, metrics | References to concepts in external glossaries or ontologies via a SKOS-based open predicate vocabulary (`target`, `predicate`, `provenance`) |
| `hidden` | fields, metrics | Hide from consumer UIs while remaining available in expressions |
| `group_label` | fields, metrics | Organizational grouping for UI presentation |
| `desired_direction` | metrics only | KPI polarity: `higher_is_better`, `lower_is_better`, `neutral` |
| `default_aggregation` | fields only | Default aggregation when field is used as a measure |
| `default_time_granularity` | fields only | Default time bucket for temporal fields: `day`, `week`, `month`, `quarter`, `year` |

### Design principles

- **Non-executional**: no field affects query execution
- **Optional and backward compatible**: all existing models remain valid
- **Consumer-focused**: designed for BI tools, AI agents, and developers

### Community input incorporated

Dragos Crintea (maintainer of semantido, a SQLAlchemy-based semantic layer used in capital-markets/regulatory-reporting contexts) provided substantive feedback that has been incorporated into this PR:

1. `glossary_references` uses an **open predicate vocabulary** (SKOS baseline: `exactMatch`, `closeMatch`, `broadMatch`, `narrowMatch`, `relatedMatch`) rather than a closed enum, allowing non-positive assertions like `DISTINCT_FROM` via extensions. This addresses the regulatory homonym problem — e.g., "Counterparty" under EMIR and "Counterparty" under MiFIR are distinct concepts that should not be conflated.
2. `semantic_type` accepts either a **well-known token or a URI**, keeping simple cases simple while supporting governed external type systems (ISO 20022, FIBO, SKOS vocabularies, LEI, ISIN, etc.).

Dragos has also offered to contribute a reference implementation in the semantido-OSI converter and benchmark data showing accuracy improvements from this class of metadata. Those contributions will follow in subsequent PRs.

### Naming

`glossary_references` was originally proposed as `semantic_mappings`; renamed per review input from Khushboo. The name describes what the field carries more directly — pointers to concepts in an external glossary, ontology, or standard — and avoids confusion with `semantic_type`. The structure is unchanged.

### Impact on existing implementations

None — all additions are optional. The JSON schema uses `additionalProperties: false` per existing convention; all new fields are added explicitly to the `Field` and `Metric` definitions.

### Related discussions

- Discussion #42 (Semantic typing): https://github.com/apache/ossie/discussions/42
- Discussion #43 (Aggregation semantics): https://github.com/apache/ossie/discussions/43
- Discussion #55 (Metadata extensibility): https://github.com/apache/ossie/discussions/55
- Issue #100: https://github.com/apache/ossie/issues/100

### AI disclosure

This contribution was developed with AI assistance (Snowflake Cortex Code). The author (Josh Klahr) has reviewed all changes and is personally responsible for the content per the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

Co-Authored-By: Cortex Code <noreply@snowflake.com>

