### PR TITLE
doc: Fix Markdown formatting in expression language specification

### DIFF
--- a/core-spec/expression_language.md
+++ b/core-spec/expression_language.md
@@ -389,6 +389,7 @@ is not guaranteed identical across engines.
 **Fractional seconds** are available everywhere but the token and precision differ
 (Oracle `FF1`–`FF9`, `strftime` `%f`, Java `S`…`SSSSSS`); treat sub-second formatting as
 a dialect extension.
+
 ---
 
 ## String Functions
@@ -674,6 +675,7 @@ expression:
 ### Dialect-Specific Extensions
 
 Vendors may expose their own feature through extensions, however the default for Ossie should be to pass unknown values through.:  
+
 ---
 
 ## Cross-Reference: Tool Mappings

--- a/core-spec/expression_language.md
+++ b/core-spec/expression_language.md
@@ -398,7 +398,7 @@ a dialect extension.
 | Function | Syntax | Description |
 | :---- | :---- | :---- |
 | `CONCAT` | `CONCAT(str1, str2, ...)` | Concatenate strings |
-| `||` | `str1 || str2` | Concatenation operator |
+| `\|\|` | `str1 \|\| str2` | Concatenation operator |
 | `LENGTH` | `LENGTH(str)` | String length in characters |
 | `LOWER` | `LOWER(str)` | Convert to lowercase |
 | `UPPER` | `UPPER(str)` | Convert to uppercase |
@@ -664,7 +664,7 @@ expression:
 | :---- | :---- | :---- | :---- | :---- | :---- |
 | Date truncation | `DATE_TRUNC('month', d)` | `DATE_TRUNC('month', d)` | `DATE_TRUNC(d, MONTH)` | `DATE_TRUNC('month', d)` | `DATE_TRUNC('month', d)` |
 | Date add | `DATEADD(day, 7, d)` | `DATEADD(day, 7, d)` | `DATE_ADD(d, INTERVAL 7 DAY)` | `DATE_ADD(d, 7)` | `d + INTERVAL '7 days'` |
-| String concat | `CONCAT(a, b)` | `CONCAT(a, b)` | `CONCAT(a, b)` | `CONCAT(a, b)` | `a || b` |
+| String concat | `CONCAT(a, b)` | `CONCAT(a, b)` | `CONCAT(a, b)` | `CONCAT(a, b)` | `a \|\| b` |
 | Null coalesce | `COALESCE(a, b)` | `COALESCE(a, b)` or `NVL(a, b)` | `COALESCE(a, b)` or `IFNULL(a, b)` | `COALESCE(a, b)` | `COALESCE(a, b)` |
 | Current timestamp | `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP` |
 | Substring | `SUBSTRING(s, start, len)` | `SUBSTR(s, start, len)` | `SUBSTR(s, start, len)` | `SUBSTRING(s, start, len)` | `SUBSTRING(s, start, len)` |


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Fix Markdown rendering issues in `core-spec/expression_language.md`:

- Escape the `||` concatenation operator inside Markdown tables to prevent it from being interpreted as a column separator.
- Add spacing before section dividers so they render correctly.
- Make no semantic changes to the expression language specification.

## Related Issues

## Validation

before:
<img width="936" height="195" alt="image" src="https://github.com/user-attachments/assets/738173e3-b226-4df4-ab3e-8aadf791b720" />
<img width="1167" height="489" alt="image" src="https://github.com/user-attachments/assets/ba45fab8-c6b5-4504-b52b-58aadf9f9d3a" />
<img width="1226" height="257" alt="image" src="https://github.com/user-attachments/assets/7cbbeac1-c09e-4151-a8ba-138bb574f61e" />
<img width="1141" height="255" alt="image" src="https://github.com/user-attachments/assets/c4d22a52-819e-429c-bbf3-05e5ab69357e" />

after:
<img width="913" height="275" alt="image" src="https://github.com/user-attachments/assets/1548fc57-4ec1-4785-b66a-b400641fe5ac" />
<img width="1262" height="404" alt="image" src="https://github.com/user-attachments/assets/d8057934-ee4c-4cf7-9ade-ca3ab532f26b" />
<img width="1207" height="247" alt="image" src="https://github.com/user-attachments/assets/e747f8f8-ec34-4f06-957e-bbcbfc2a4389" />
<img width="1275" height="220" alt="image" src="https://github.com/user-attachments/assets/4b698ba3-fa44-4168-9331-fbc8ffd7c147" />
