### PR TITLE
Validate relationship column pair counts

### DIFF
--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 # validate.py exits at import time when its dependencies are missing, which
-# would abort the whole pytest session during collection — skip instead.
+# would abort the whole pytest session during collection -- skip instead.
 pytest.importorskip("yaml")
 pytest.importorskip("jsonschema")
 
@@ -57,14 +57,25 @@ _CUSTOMERS = {
 _ORDERS = {"name": "orders", "source": "db.s.orders"}
 
 
-def _relationship(to_columns: list[str], to: str = "customers") -> dict:
+def _relationship(
+    to_columns: list[str],
+    to: str = "customers",
+    from_columns: list[str] | None = None,
+) -> dict:
     return {
         "name": "orders_to_customers",
         "from": "orders",
         "to": to,
-        "from_columns": ["customer_id"],
+        "from_columns": from_columns or ["customer_id"],
         "to_columns": to_columns,
     }
+
+
+def _document_with_relationship(from_columns: list[str], to_columns: list[str]) -> dict:
+    rel = _relationship(to_columns=to_columns)
+    rel["from_columns"] = from_columns
+    customers = {"name": "customers", "source": "db.s.customers"}
+    return _document([_ORDERS, customers], [rel])
 
 
 def test_warns_when_to_columns_does_not_cover_a_declared_key() -> None:
@@ -98,7 +109,15 @@ def test_accepts_to_columns_that_is_a_superset_of_a_key() -> None:
     # e.g. tenant-sharded joins carry extra columns on top of the key;
     # coverage still guarantees the many-to-one semantics.
     errors = validate_references(
-        _document([_ORDERS, _CUSTOMERS], [_relationship(to_columns=["tenant_id", "id"])])
+        _document(
+            [_ORDERS, _CUSTOMERS],
+            [
+                _relationship(
+                    from_columns=["tenant_id", "customer_id"],
+                    to_columns=["tenant_id", "id"],
+                )
+            ],
+        )
     )
 
     assert errors == []
@@ -110,7 +129,11 @@ def test_accepts_composite_key_regardless_of_column_order() -> None:
         "source": "db.s.order_lines",
         "primary_key": ["order_id", "line_number"],
     }
-    rel = _relationship(to_columns=["line_number", "order_id"], to="order_lines")
+    rel = _relationship(
+        from_columns=["line_number", "order_id"],
+        to_columns=["line_number", "order_id"],
+        to="order_lines",
+    )
 
     assert validate_references(_document([_ORDERS, composite], [rel])) == []
 
@@ -134,8 +157,12 @@ def test_still_reports_unknown_datasets() -> None:
 
 def test_tolerates_null_unique_keys() -> None:
     # `unique_keys:` present but empty parses to None; the check must not crash.
-    dataset = {"name": "customers", "source": "db.s.customers",
-               "primary_key": ["id"], "unique_keys": None}
+    dataset = {
+        "name": "customers",
+        "source": "db.s.customers",
+        "primary_key": ["id"],
+        "unique_keys": None,
+    }
     errors = validate_references(
         _document([_ORDERS, dataset], [_relationship(to_columns=["id"])])
     )
@@ -152,12 +179,44 @@ def test_skips_non_list_to_columns() -> None:
     assert validate_references(_document([_ORDERS, _CUSTOMERS], [rel])) == []
 
 
+def test_skips_non_list_from_columns() -> None:
+    rel = _relationship(to_columns=["id"])
+    rel["from_columns"] = "customer_id"
+
+    assert validate_references(_document([_ORDERS, _CUSTOMERS], [rel])) == []
+
+
 def test_skips_malformed_flat_unique_keys() -> None:
     # unique_keys mistakenly written flat like primary_key: strings are not
     # keys, so with no well-formed key declared the check does not fire.
     dataset = {"name": "customers", "source": "db.s.customers", "unique_keys": ["email"]}
     errors = validate_references(
         _document([_ORDERS, dataset], [_relationship(to_columns=["email"])])
+    )
+
+    assert errors == []
+
+
+def test_validate_references_rejects_mismatched_relationship_column_counts() -> None:
+    errors = validate_references(
+        _document_with_relationship(
+            from_columns=["customer_id", "region_id"],
+            to_columns=["id"],
+        )
+    )
+
+    assert errors == [
+        "[Relationship] Relationship 'orders_to_customers' in model 'm' has "
+        "2 from_columns but 1 to_columns"
+    ]
+
+
+def test_validate_references_accepts_matching_relationship_column_counts() -> None:
+    errors = validate_references(
+        _document_with_relationship(
+            from_columns=["customer_id", "region_id"],
+            to_columns=["id", "region_id"],
+        )
     )
 
     assert errors == []

--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -1,0 +1,60 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_VALIDATE_PATH = Path(__file__).parents[1] / "validate.py"
+_SPEC = spec_from_file_location("ossie_validate", _VALIDATE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_VALIDATE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_VALIDATE)
+
+validate_references = _VALIDATE.validate_references
+
+
+def _document_with_relationship(from_columns: list[str], to_columns: list[str]) -> dict:
+    return {
+        "version": "0.2.0.dev0",
+        "semantic_model": [
+            {
+                "name": "m",
+                "datasets": [
+                    {"name": "orders", "source": "db.s.orders"},
+                    {"name": "customers", "source": "db.s.customers"},
+                ],
+                "relationships": [
+                    {
+                        "name": "orders_to_customers",
+                        "from": "orders",
+                        "to": "customers",
+                        "from_columns": from_columns,
+                        "to_columns": to_columns,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_validate_references_rejects_mismatched_relationship_column_counts() -> None:
+    errors = validate_references(
+        _document_with_relationship(
+            from_columns=["customer_id", "region_id"],
+            to_columns=["id"],
+        )
+    )
+
+    assert errors == [
+        "[Relationship] Relationship 'orders_to_customers' in model 'm' has "
+        "2 from_columns but 1 to_columns"
+    ]
+
+
+def test_validate_references_accepts_matching_relationship_column_counts() -> None:
+    errors = validate_references(
+        _document_with_relationship(
+            from_columns=["customer_id", "region_id"],
+            to_columns=["id", "region_id"],
+        )
+    )
+
+    assert errors == []

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -140,11 +140,18 @@ def validate_references(data: dict) -> list[str]:
             rel_name = rel.get("name", "<unnamed>")
             from_ds = rel.get("from")
             to_ds = rel.get("to")
+            from_columns = rel.get("from_columns") or []
+            to_columns = rel.get("to_columns") or []
 
             if from_ds and from_ds not in dataset_names:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{from_ds}'")
             if to_ds and to_ds not in dataset_names:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{to_ds}'")
+            if len(from_columns) != len(to_columns):
+                errors.append(
+                    f"[Relationship] Relationship '{rel_name}' in model '{model_name}' has "
+                    f"{len(from_columns)} from_columns but {len(to_columns)} to_columns"
+                )
 
     return errors
 

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -141,11 +141,22 @@ def validate_references(data: dict) -> list[str]:
             rel_name = rel.get("name", "<unnamed>")
             from_ds = rel.get("from")
             to_ds = rel.get("to")
+            from_columns = rel.get("from_columns")
+            to_columns = rel.get("to_columns")
 
             if from_ds and from_ds not in datasets:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{from_ds}'")
             if to_ds and to_ds not in datasets:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{to_ds}'")
+            if (
+                isinstance(from_columns, list)
+                and isinstance(to_columns, list)
+                and len(from_columns) != len(to_columns)
+            ):
+                errors.append(
+                    f"[Relationship] Relationship '{rel_name}' in model '{model_name}' has "
+                    f"{len(from_columns)} from_columns but {len(to_columns)} to_columns"
+                )
 
             # The spec defines to_columns as "Primary/unique key columns in the
             # 'to' dataset". Coverage (superset of a key) still guarantees the


### PR DESCRIPTION
## Why

The OSI spec requires `from_columns` and `to_columns` in a relationship to have the same number of columns so each source column maps to one target column. The validator checked that relationship datasets existed, but did not enforce this cardinality rule, so invalid relationship definitions could pass validation and be silently truncated by downstream converters that zip the two arrays.

## What changed

- Added a relationship-level validation check in `validation/validate.py` for mismatched `from_columns` / `to_columns` lengths.
- Report mismatches with a clear `[Relationship]` error that includes the relationship name, model name, and both column counts.
- Added validation unit tests for both mismatched and matching relationship column arrays.

## Tests added/updated

- `validation/tests/test_validate.py::test_validate_references_rejects_mismatched_relationship_column_counts`
- `validation/tests/test_validate.py::test_validate_references_accepts_matching_relationship_column_counts`

## Verification

- `uv run --with pytest --with pyyaml --with jsonschema --with sqlglot pytest validation/tests/test_validate.py -q`
- `uv run validation/validate.py examples/tpcds_semantic_model.yaml`
- Verified an invalid temporary OSI document now fails validation with `2 from_columns but 1 to_columns`.
