### PR TITLE
Core spec: allow ai_context on the document root

### DIFF
--- a/.github/workflows/validation-ci.yml
+++ b/.github/workflows/validation-ci.yml
@@ -26,6 +26,7 @@ on:
       - "validation/**"
       - "core-spec/**"
       - "examples/tpcds_semantic_model.yaml"
+      - "examples/multi_model_ai_context.yaml"
       - ".github/workflows/validation-ci.yml"
   pull_request:
     branches: ["main"]
@@ -33,6 +34,7 @@ on:
       - "validation/**"
       - "core-spec/**"
       - "examples/tpcds_semantic_model.yaml"
+      - "examples/multi_model_ai_context.yaml"
       - ".github/workflows/validation-ci.yml"
 
 jobs:
@@ -64,3 +66,6 @@ jobs:
 
       - name: Validate canonical example
         run: uv run validation/validate.py examples/tpcds_semantic_model.yaml
+
+      - name: Validate document-wide ai_context example
+        run: uv run validation/validate.py examples/multi_model_ai_context.yaml

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -10,11 +10,22 @@
       "const": "0.2.0.dev0",
       "description": "Apache Ossie specification version"
     },
+    "ai_context": {
+      "$ref": "#/$defs/AIContext",
+      "description": "Document-wide context for AI tools. Applies to every semantic model in this document; model-level ai_context adds to it and takes precedence where the two conflict."
+    },
     "semantic_model": {
       "type": "array",
       "description": "Collection of semantic model definitions",
       "items": {
         "$ref": "#/$defs/SemanticModel"
+      }
+    },
+    "custom_extensions": {
+      "type": "array",
+      "description": "Document-wide vendor-specific attributes for extensibility",
+      "items": {
+        "$ref": "#/$defs/CustomExtension"
       }
     }
   },

--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -10,6 +10,10 @@
       "const": "0.2.0.dev0",
       "description": "Apache Ossie specification version"
     },
+    "ai_context": {
+      "$ref": "#/$defs/AIContext",
+      "description": "Document-wide context for AI tools. Applies to every semantic model in this document."
+    },
     "semantic_model": {
       "type": "array",
       "description": "Collection of semantic model definitions",

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -32,12 +32,13 @@
 ## Table of Contents
 
 1. [Enumerations](#enumerations)
-2. [Semantic Model](#semantic-model)
-3. [Datasets](#datasets)
-4. [Relationships](#relationships)
-5. [Fields](#fields)
-6. [Metrics](#metrics)
-7. [Examples](#examples)
+2. [Document](#document)
+3. [Semantic Model](#semantic-model)
+4. [Datasets](#datasets)
+5. [Relationships](#relationships)
+6. [Fields](#fields)
+7. [Metrics](#metrics)
+8. [Examples](#examples)
 
 ---
 
@@ -78,6 +79,66 @@ ontology specification's built-in value types; `Time`, `DateTimeTz`, and
 | `DateTime` | Local/civil date and time with no timezone or offset. |
 | `DateTimeTz` | Date and time with sufficient offset or timezone context to identify an instant. Preservation of a named timezone identifier is not guaranteed. |
 | `Opaque` | Known type outside the portable vocabulary; use `custom_extensions` for vendor-specific refinement. Omit `datatype` when the type is unknown or unspecified. |
+
+## Document
+
+The root object of an Ossie file. A document carries a specification `version` and one or
+more semantic models.
+
+### Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | Yes | Apache Ossie specification version |
+| `ai_context` | string/object | No | Document-wide context for AI tools |
+| `semantic_model` | array | Yes | Collection of semantic model definitions |
+| `custom_extensions` | array | No | Document-wide vendor-specific attributes for extensibility |
+
+### Document-wide `ai_context`
+
+A document may hold several semantic models — for example one per data source, where each
+model is queried in its own dialect. Guidance that governs all of them (domain conventions,
+a shared glossary, rules the publisher considers mandatory) belongs to the document, not to
+any one model. Without a document-level slot, a producer has to copy that guidance into
+every model so that no model can be read without it, and a consumer has no way to tell the
+copies apart from genuinely model-specific instruction.
+
+`ai_context` at the root states it once:
+
+```yaml
+version: 0.2.0.dev0
+ai_context:
+  instructions: "Fiscal year starts in July. Never join across the finance and telemetry models."
+  synonyms: ["revenue = net_sales"]
+semantic_model:
+  - name: finance
+    ai_context:
+      instructions: "Amounts are in USD."
+    datasets:
+      - name: gl_entries
+        source: finance.public.gl_entries
+  - name: telemetry
+    datasets:
+      - name: events
+        source: telemetry.public.events
+```
+
+Document-level context applies to every model in the document. Model-level `ai_context` adds
+to it rather than replacing it, and takes precedence where the two conflict — so `finance`
+above is read as "fiscal year starts in July" *and* "amounts are in USD". The root slot
+carries no instruction that is specific to one model; that is what the model-level slot is
+for.
+
+Consumers that do not understand document-level context still parse the document, and models
+remain independently readable — but a consumer that ignores it will miss guidance the
+publisher considered mandatory, exactly as it would by ignoring model-level `ai_context`.
+
+An ontology document already works this way: `ontology/ontology.json` carries `ai_context` on
+its root and resolves it against this specification's `AIContext` definition, so document-wide
+context is an established shape in Ossie rather than a new one. Core documents were the only
+root without it.
+
+---
 
 ## Semantic Model
 

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -32,12 +32,13 @@
 ## Table of Contents
 
 1. [Enumerations](#enumerations)
-2. [Semantic Model](#semantic-model)
-3. [Datasets](#datasets)
-4. [Relationships](#relationships)
-5. [Fields](#fields)
-6. [Metrics](#metrics)
-7. [Examples](#examples)
+2. [Document](#document)
+3. [Semantic Model](#semantic-model)
+4. [Datasets](#datasets)
+5. [Relationships](#relationships)
+6. [Fields](#fields)
+7. [Metrics](#metrics)
+8. [Examples](#examples)
 
 ---
 
@@ -79,6 +80,44 @@ ontology specification's built-in value types; `Time`, `DateTimeTz`, and
 | `DateTime` | Local/civil date and time with no timezone or offset. |
 | `DateTimeTz` | Date and time with sufficient offset or timezone context to identify an instant. Preservation of a named timezone identifier is not guaranteed. |
 | `Opaque` | Known type outside the portable vocabulary; use `custom_extensions` for vendor-specific refinement. Omit `datatype` when the type is unknown or unspecified. |
+
+## Document
+
+The root object of an Ossie file. A document carries a specification `version` and one or
+more semantic models.
+
+### Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | Yes | Apache Ossie specification version |
+| `ai_context` | string/object | No | Document-wide context for AI tools |
+| `semantic_model` | array | Yes | Collection of semantic model definitions |
+
+### Document-wide `ai_context`
+
+A document may hold several semantic models — for example one per data source. Guidance that
+governs all of them belongs to the document rather than to any one model, and stating it at
+the root avoids copying it into every model, where the copies drift and a consumer cannot
+tell them apart from genuinely model-specific instruction.
+
+```yaml
+version: 0.2.0.dev0
+ai_context:
+  instructions: "Fiscal year starts in July. Never join across the finance and telemetry models."
+semantic_model:
+  - name: finance
+    ai_context:
+      instructions: "Amounts are in USD."
+    datasets: [...]
+  - name: telemetry
+    datasets: [...]
+```
+
+Document-level `ai_context` applies to every semantic model in the document. How it composes
+with model-level `ai_context` is not defined by this version of the specification.
+
+---
 
 ## Semantic Model
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -58,13 +58,20 @@ datatypes:
 vendor_name: string
 
 
+---
+# Document root
+# Keys allowed on the root object of an Ossie document, alongside the `version`
+# declared at the top of this file and the `semantic_model` list defined below.
+
 # Optional: Document-wide context for AI tools.
 # Applies to every semantic model in this document. Model-level ai_context adds to
 # it and takes precedence where the two conflict.
 # Use this for guidance that governs the document as a whole — a model read in
 # isolation would otherwise have to repeat it.
-# Can be a simple string or a structured object with instructions,
-# synonyms, examples, or vendor-specific keys.
+# Can be a simple string or a structured object with instructions, synonyms,
+# examples, or vendor-specific keys. The structured form is shown here; see the
+# authoritative AIContext definition in osi-schema.json, which accepts both forms
+# wherever ai_context appears.
 ai_context:
   instructions: string
   synonyms:

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -58,6 +58,26 @@ datatypes:
 vendor_name: string
 
 
+# Optional: Document-wide context for AI tools.
+# Applies to every semantic model in this document. Model-level ai_context adds to
+# it and takes precedence where the two conflict.
+# Use this for guidance that governs the document as a whole — a model read in
+# isolation would otherwise have to repeat it.
+# Can be a simple string or a structured object with instructions,
+# synonyms, examples, or vendor-specific keys.
+ai_context:
+  instructions: string
+  synonyms:
+    - string
+  examples:
+    - string
+
+# Optional: Document-wide vendor-specific attributes for extensibility
+custom_extensions:
+  - vendor_name: string  # Free-form string identifying the vendor
+    data: string
+
+
 # Top-level semantic model definition
 semantic_model:
   # Required: Unique identifier for the semantic model

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -59,6 +59,11 @@ datatypes:
 vendor_name: string
 
 
+---
+# Document root
+# Keys allowed on the root object of an Ossie document, alongside the `version`
+# declared at the top of this file.
+
 # Top-level semantic model definition
 semantic_model:
   # Required: Unique identifier for the semantic model

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -64,6 +64,19 @@ vendor_name: string
 # Keys allowed on the root object of an Ossie document, alongside the `version`
 # declared at the top of this file.
 
+# Optional: Document-wide context for AI tools.
+# Applies to every semantic model in this document. Use this for guidance that
+# governs the document as a whole, rather than repeating it in every model.
+# Can be a simple string or a structured object; see the authoritative AIContext
+# definition in ossie-schema.json, which accepts both forms wherever ai_context
+# appears.
+ai_context:
+  instructions: string
+  synonyms:
+    - string
+  examples:
+    - string
+
 # Top-level semantic model definition
 semantic_model:
   # Required: Unique identifier for the semantic model

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ The Ossie core specification (current version: **0.2.0.dev0**, latest released: 
 | **Relationships** | Foreign key connections between datasets, supporting both simple and composite keys. |
 | **Metrics** | Quantitative measures (sums, averages, ratios, etc.) defined at the model level, capable of spanning multiple datasets. |
 | **Custom Extensions** | Vendor-specific metadata stored as JSON, allowing platforms to carry additional information without breaking core compatibility. |
-| **AI Context** | Optional annotations at every level (model, dataset, field, relationship, metric) to help AI tools understand business meaning — including instructions, synonyms, and example queries. |
+| **AI Context** | Optional annotations at every level (document, model, dataset, field, relationship, metric) to help AI tools understand business meaning — including instructions, synonyms, and example queries. |
 
 The specification supports multiple SQL dialects (`ANSI_SQL`, `SNOWFLAKE`, `DATABRICKS`, `MDX`, `TABLEAU`) so that expressions can be tailored to each platform while maintaining a common model structure.
 
@@ -322,7 +322,7 @@ A practical guide for organizations looking to adopt Ossie.
 | **Relationship** | A foreign key connection between two datasets, defining how they can be joined. Relationships are always many-to-one (from the referencing dataset to the referenced dataset). |
 | **Dialect** | A specific SQL or expression language variant (e.g., `ANSI_SQL`, `SNOWFLAKE`, `DATABRICKS`). Ossie supports multiple dialects so expressions can be tailored to each platform. |
 | **Custom Extension** | Vendor-specific metadata attached to any Ossie construct as a JSON string. Extensions allow platforms to carry additional information without modifying the core specification. |
-| **AI Context** | Optional annotations on any Ossie construct (model, dataset, field, relationship, metric) that provide additional context for AI tools — including natural language instructions, synonyms, and example queries. |
+| **AI Context** | Optional annotations on any Ossie construct (document, model, dataset, field, relationship, metric) that provide additional context for AI tools — including natural language instructions, synonyms, and example queries. Document-level context applies to every semantic model in the document; model-level context adds to it and takes precedence on conflict. |
 | **Converter** | A tool that translates between the Ossie format and a specific vendor's semantic model format. Converters come in pairs: import (vendor → Ossie) and export (Ossie → vendor). |
 | **Hub-and-Spoke** | The architectural pattern used by Ossie, where the specification acts as the central format (hub) and vendor converters act as spokes, avoiding the need for point-to-point integrations. |
 | **Round-Trip Fidelity** | The ability to convert a model from one format to Ossie and back without losing information. Achieved by preserving vendor-specific metadata in `custom_extensions`. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ The Ossie core specification (current version: **0.2.0.dev0**, latest released: 
 | **Relationships** | Foreign key connections between datasets, supporting both simple and composite keys. |
 | **Metrics** | Quantitative measures (sums, averages, ratios, etc.) defined at the model level, capable of spanning multiple datasets. |
 | **Custom Extensions** | Vendor-specific metadata stored as JSON, allowing platforms to carry additional information without breaking core compatibility. |
-| **AI Context** | Optional annotations at every level (model, dataset, field, relationship, metric) to help AI tools understand business meaning — including instructions, synonyms, and example queries. |
+| **AI Context** | Optional annotations at every level (document, model, dataset, field, relationship, metric) to help AI tools understand business meaning — including instructions, synonyms, and example queries. |
 
 The specification supports multiple SQL dialects (`ANSI_SQL`, `SNOWFLAKE`, `DATABRICKS`, `MDX`, `TABLEAU`) so that expressions can be tailored to each platform while maintaining a common model structure.
 
@@ -322,7 +322,7 @@ A practical guide for organizations looking to adopt Ossie.
 | **Relationship** | A foreign key connection between two datasets, defining how they can be joined. Relationships are always many-to-one (from the referencing dataset to the referenced dataset). |
 | **Dialect** | A specific SQL or expression language variant (e.g., `ANSI_SQL`, `SNOWFLAKE`, `DATABRICKS`). Ossie supports multiple dialects so expressions can be tailored to each platform. |
 | **Custom Extension** | Vendor-specific metadata attached to any Ossie construct as a JSON string. Extensions allow platforms to carry additional information without modifying the core specification. |
-| **AI Context** | Optional annotations on any Ossie construct (model, dataset, field, relationship, metric) that provide additional context for AI tools — including natural language instructions, synonyms, and example queries. |
+| **AI Context** | Optional annotations on any Ossie construct (document, model, dataset, field, relationship, metric) that provide additional context for AI tools — including natural language instructions, synonyms, and example queries. |
 | **Converter** | A tool that translates between the Ossie format and a specific vendor's semantic model format. Converters come in pairs: import (vendor → Ossie) and export (Ossie → vendor). |
 | **Hub-and-Spoke** | The architectural pattern used by Ossie, where the specification acts as the central format (hub) and vendor converters act as spokes, avoiding the need for point-to-point integrations. |
 | **Round-Trip Fidelity** | The ability to convert a model from one format to Ossie and back without losing information. Achieved by preserving vendor-specific metadata in `custom_extensions`. |

--- a/examples/multi_model_ai_context.yaml
+++ b/examples/multi_model_ai_context.yaml
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Document-wide ai_context
+#
+# This document holds two semantic models, one per data source, each queried in
+# its own dialect. The guidance at the root governs both of them: it states the
+# publisher's conventions once, instead of being copied into every model where
+# the copies drift and a consumer cannot tell them apart from instruction that
+# is genuinely specific to one model.
+#
+# Model-level ai_context remains the place for anything true of only that model
+# ("amounts are in USD" below).
+
+version: "0.2.0.dev0"
+
+ai_context:
+  instructions: "The fiscal year starts in July: a date in July 2024 belongs to FY2025. These two models come from separate systems and share no keys, so never join across them; answer questions that span both by querying each and reporting the results side by side."
+  synonyms:
+    - "revenue = net_sales"
+
+semantic_model:
+  - name: finance
+    description: General ledger, sourced from the accounting warehouse.
+    ai_context:
+      instructions: "Amounts are in USD. Rows with a null posted_at are drafts and must be excluded."
+
+    datasets:
+      - name: gl_entries
+        source: finance.public.gl_entries
+        primary_key: [entry_id]
+        description: One row per posted general ledger entry.
+        fields:
+          - name: entry_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: entry_id
+            datatype: Integer
+            description: Surrogate key of the ledger entry.
+
+          - name: net_sales
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: net_sales
+            datatype: Decimal
+            description: Net sales amount for the entry.
+
+          - name: posted_at
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: posted_at
+            datatype: DateTime
+            description: When the entry was posted; null for drafts.
+            dimension:
+              is_time: true
+
+  - name: telemetry
+    description: Product usage events, sourced from the telemetry lakehouse.
+
+    datasets:
+      - name: events
+        source: telemetry.public.events
+        primary_key: [event_id]
+        description: One row per emitted product usage event.
+        fields:
+          - name: event_id
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: event_id
+            datatype: String
+            description: Unique identifier of the event.
+
+          - name: occurred_at
+            expression:
+              dialects:
+                - dialect: DATABRICKS
+                  expression: occurred_at
+            datatype: DateTimeTz
+            description: When the event was emitted.
+            dimension:
+              is_time: true

--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -211,7 +211,9 @@ class OSIDocument(BaseModel):
     version: str = "0.2.0.dev0"
     dialects: Optional[list[OSIDialect]] = None
     vendors: Optional[list[OSIVendor]] = None
+    ai_context: Optional[OSIAIContext] = None
     semantic_model: list[OSISemanticModel]
+    custom_extensions: Optional[list[OSICustomExtension]] = None
 
     def to_osi_yaml(self, **kwargs: Any) -> str:
         """Serialize to Ossie-compliant YAML (uses field aliases and excludes None values)."""

--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -212,6 +212,7 @@ class OssieDocument(BaseModel):
     version: str = "0.2.0.dev0"
     dialects: Optional[list[OssieDialect]] = None
     vendors: Optional[list[OssieVendor]] = None
+    ai_context: Optional[OssieAIContext] = None
     semantic_model: list[OssieSemanticModel]
 
     def to_ossie_yaml(self, **kwargs: Any) -> str:

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -111,6 +111,81 @@ def test_invalid_datatype_is_rejected() -> None:
         OSIDocument.model_validate(document)
 
 
+def test_document_ai_context_matches_core_schema() -> None:
+    schema_path = Path(__file__).parents[2] / "core-spec" / "osi-schema.json"
+    schema = json.loads(schema_path.read_text())
+
+    assert schema["properties"]["ai_context"]["$ref"] == "#/$defs/AIContext"
+    assert schema["properties"]["custom_extensions"]["items"] == {
+        "$ref": "#/$defs/CustomExtension"
+    }
+
+    # Document-wide context is optional: a document without it stays valid, so
+    # existing documents keep validating unchanged.
+    assert "ai_context" not in schema["required"]
+    assert "custom_extensions" not in schema["required"]
+
+    # The root stays closed; the two new keys are the only additions.
+    assert schema["additionalProperties"] is False
+
+
+def test_document_ai_context_agrees_with_the_ontology_root() -> None:
+    """Both document roots carry ai_context, resolved against the same definition.
+
+    The ontology specification already puts ai_context on its root and $refs this
+    specification's AIContext. If that reference is ever repointed at a different
+    definition, the two document types would silently disagree about what
+    document-wide context means.
+    """
+    core = json.loads(
+        (Path(__file__).parents[2] / "core-spec" / "osi-schema.json").read_text()
+    )
+    ontology = json.loads(
+        (Path(__file__).parents[2] / "ontology" / "ontology.json").read_text()
+    )
+
+    assert ontology["properties"]["ai_context"]["$ref"].endswith(
+        "osi-schema.json#/$defs/AIContext"
+    )
+    assert core["properties"]["ai_context"]["$ref"] == "#/$defs/AIContext"
+
+
+def test_document_ai_context_survives_serialization() -> None:
+    document = _document()
+    document["ai_context"] = {
+        "instructions": "Fiscal year starts in July.",
+        "synonyms": ["revenue = net_sales"],
+    }
+    document["custom_extensions"] = [{"vendor_name": "COMMON", "data": "{}"}]
+
+    parsed = OSIDocument.model_validate(document)
+    assert parsed.ai_context.instructions == "Fiscal year starts in July."
+    assert parsed.custom_extensions[0].vendor_name == "COMMON"
+
+    for serialized in (
+        json.loads(parsed.to_osi_json()),
+        yaml.safe_load(parsed.to_osi_yaml()),
+    ):
+        assert serialized["ai_context"]["instructions"] == "Fiscal year starts in July."
+        assert serialized["custom_extensions"][0]["vendor_name"] == "COMMON"
+
+
+def test_document_ai_context_accepts_the_string_form() -> None:
+    document = _document()
+    document["ai_context"] = "Fiscal year starts in July."
+
+    parsed = OSIDocument.model_validate(document)
+    assert parsed.ai_context == "Fiscal year starts in July."
+
+
+def test_document_without_ai_context_omits_it() -> None:
+    parsed = OSIDocument.model_validate(_document())
+
+    assert parsed.ai_context is None
+    assert "ai_context" not in yaml.safe_load(parsed.to_osi_yaml())
+    assert "custom_extensions" not in json.loads(parsed.to_osi_json())
+
+
 @pytest.mark.parametrize(
     ("dimension", "datatype", "expected"),
     [

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -111,6 +111,64 @@ def test_invalid_datatype_is_rejected() -> None:
         OssieDocument.model_validate(document)
 
 
+def test_document_ai_context_matches_core_schema() -> None:
+    schema_path = Path(__file__).parents[2] / "core-spec" / "ossie-schema.json"
+    schema = json.loads(schema_path.read_text())
+
+    assert schema["properties"]["ai_context"]["$ref"] == "#/$defs/AIContext"
+
+    # Document-wide context is optional, so existing documents keep validating
+    # unchanged, and the root stays closed to anything else.
+    assert "ai_context" not in schema["required"]
+    assert schema["additionalProperties"] is False
+
+
+def test_document_ai_context_agrees_with_the_ontology_root() -> None:
+    """Both document roots resolve ai_context against the same definition.
+
+    The ontology specification already puts ai_context on its root and $refs this
+    specification's AIContext. If that reference is ever repointed at a different
+    definition, the two document types would silently disagree about what
+    document-wide context means.
+    """
+    core = json.loads(
+        (Path(__file__).parents[2] / "core-spec" / "ossie-schema.json").read_text()
+    )
+    ontology = json.loads(
+        (Path(__file__).parents[2] / "ontology" / "ontology.json").read_text()
+    )
+
+    assert ontology["properties"]["ai_context"]["$ref"].endswith(
+        "ossie-schema.json#/$defs/AIContext"
+    )
+    assert core["properties"]["ai_context"]["$ref"] == "#/$defs/AIContext"
+
+
+def test_document_ai_context_survives_serialization() -> None:
+    """Both forms of AIContext round-trip, and an absent one does not serialize."""
+    document = _document()
+    document["ai_context"] = {
+        "instructions": "Fiscal year starts in July.",
+        "synonyms": ["revenue = net_sales"],
+    }
+
+    parsed = OssieDocument.model_validate(document)
+    assert parsed.ai_context.instructions == "Fiscal year starts in July."
+    for serialized in (
+        json.loads(parsed.to_ossie_json()),
+        yaml.safe_load(parsed.to_ossie_yaml()),
+    ):
+        assert serialized["ai_context"]["instructions"] == "Fiscal year starts in July."
+
+    document["ai_context"] = "Fiscal year starts in July."
+    assert OssieDocument.model_validate(document).ai_context == "Fiscal year starts in July."
+
+    absent = OssieDocument.model_validate(_document())
+    assert absent.ai_context is None
+    assert "ai_context" not in yaml.safe_load(absent.to_ossie_yaml())
+    assert "ai_context" not in json.loads(absent.to_ossie_json())
+
+
 @pytest.mark.parametrize(
     ("dimension", "datatype", "expected"),
     [


### PR DESCRIPTION
## Summary

The document root is the only node in the core spec with no `ai_context`. The key appears on
`SemanticModel`, `Dataset`, `Field`, `Metric` and `Relationship`; the root is closed
(`additionalProperties: false`) with only `version` and `semantic_model`.

Since `semantic_model` is a **list**, guidance that governs every model in a document has
nowhere to live. This PR adds one optional key to the document root, reusing the existing
definition:

| Key | Type |
|-----|------|
| `ai_context` | `$ref: #/$defs/AIContext` |

**Semantics — scope only.** Document-level `ai_context` applies to every semantic model in
the document. How it *composes* with model-level `ai_context` is deliberately left undefined
by this version; see "Changes since the first review" below.

## The case

`examples/multi_model_ai_context.yaml` (new) is the motivating document: two models, one per
federated data source, each queried in its own dialect, sharing no keys.

```yaml
version: "0.2.0.dev0"

ai_context:
  instructions: "The fiscal year starts in July: a date in July 2024 belongs to FY2025.
    These two models come from separate systems and share no keys, so never join across
    them; answer questions that span both by querying each and reporting the results
    side by side."

semantic_model:
  - name: finance          # ANSI_SQL
    ai_context:
      instructions: "Amounts are in USD. Rows with a null posted_at are drafts."
    datasets: [...]
  - name: telemetry        # DATABRICKS
    datasets: [...]
```

The fiscal-year convention and the "never join across these" rule are properties of the
*document*. Today the only way to express them is to copy them into every model, which means:

- shared instruction is duplicated N times, and drifts;
- a consumer cannot distinguish "this was document-wide" from "this is genuinely specific to
  this model" — note `finance`'s USD rule above, which really *is* model-specific.

The example is wired into `validation-ci.yml` so it cannot rot. That workflow previously
validated only `examples/tpcds_semantic_model.yaml`, by hardcoded path, so a new example
would not otherwise have been checked by anything.

## Changes since the first review

Thanks to @khush-bhatia for the review — both points led to changes:

- **Dropped root `custom_extensions`.** It resembled re-adding root `vendors`, and unlike
  `ai_context` it had no motivating document. The PR is one key now.
- **Cut the precedence rule back to scope.** It previously said model-level `ai_context`
  "adds to" document-level context and "takes precedence where the two conflict". `AIContext`
  is `oneOf: [string, object]`, and neither "adds" nor "conflict" is well-defined for the
  string form. Scope alone delivers the point of #322 — say it once instead of N times — so
  composition is left to a later change with its own discussion.
- **Split the unrelated `spec.yaml` sectioning fix out** into #367, since it was noise here.

### On `dialects` / `vendors`

These look like the opposite case rather than a precedent against this change.

They were never in the schema root. `main` is `{version, semantic_model}` with
`additionalProperties: false`, so a document carrying root `dialects` is rejected by
`validate.py` today. They are fields on the Python `OssieDocument` model only, and #148/#306
remove them because the same fact is already carried at the leaf — dialect per expression,
vendor per `custom_extension`.

Document-wide `ai_context` has no leaf that already carries it. This PR also keeps the root
closed and adds nothing to `required`.

## Precedent

An ontology document already carries `ai_context` on its root, and `$ref`s *this* spec's
definition:

```json
"ai_context": { "$ref": ".../core-spec/ossie-schema.json#/$defs/AIContext" }
```

The core spec already *defines* document-wide AI context — the core document root was simply
the only root that never *consumed* it. A test pins both roots to the same `AIContext`
definition so they cannot drift.

## Not a breaking change

- No new `$defs` — the key reuses the existing definition.
- `required` is unchanged; the key is optional.
- `additionalProperties: false` is unchanged, so the root **stays closed**.
- `examples/tpcds_semantic_model.yaml` validates unchanged, and an absent key does not
  serialize.

Asserted directly against the edited schema:

| Document | Result |
|---|---|
| no `ai_context` | accepted (back-compat) |
| root `ai_context` as string | accepted |
| root `ai_context` as object | accepted |
| root `ai_context: 42` | **rejected** — not valid under any of the given schemas |
| unknown root key | **rejected** — root stays closed |
| root `custom_extensions` | **rejected** — confirms it is fully removed |
| root `dialects` | **rejected** — was never valid at the root |

## Stacked on #367

This PR is based on #367 (a 5-line, comment-only sectioning fix in `spec.yaml`) and so shows
two commits until that one merges. **Only the second commit,
"Core spec: allow ai_context on the document root", belongs to this PR.**

## Interaction with other open work

- **#148 / #306** remove root keys (`dialects`, `vendors`) from the Python model that were
  never in the schema. Compatible in substance: this PR goes the other way round — it adds to
  the schema first and leaves the root closed. Under #306's `extra="forbid"`, declared fields
  still validate.
- **#141** tracks `spec.yaml` declaring `ai_context: string` while the schema and canonical
  example use the structured object. The root entry added here shows the structured form and
  points at `AIContext` in `ossie-schema.json` as authoritative for both forms; aligning the
  four remaining model-level sites is #141's scope and is untouched here.
- **#234** asks whether `ai_context` should exist at all. That is a broader question, and a
  fair one — if the direction is to shrink `ai_context`, this PR should wait on that outcome
  rather than iterate. This PR only makes the existing construct available at the one level
  where it is missing.

## Related Issues

Refs #322

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [x] Spec changes have been discussed on the mailing list or in a linked issue — see #322
- [x] Breaking changes to the spec are clearly called out in the summary — there are none; see "Not a breaking change"

### Ontology
- [x] Ontology changes in `ontology/` are consistent with spec changes — `ontology/` is untouched; it already had root `ai_context` and this aligns core with it
- [x] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes — not applicable, the key is optional and no converter emits it
- [ ] New converters include tests under the converter's test directory — not applicable

### Validation
- [x] Validation rules in `validation/` are updated if the spec changed — `validate.py` is schema-driven and needed no change; verified positive, negative and back-compat cases against it
- [x] New validation cases are covered by tests — plus `examples/multi_model_ai_context.yaml` is now validated in CI

### Documentation
- [x] `docs/` is updated to reflect any user-facing changes
- [x] New features or behaviors are documented with examples where appropriate — new "Document" section in `spec.md`, and a full example under `examples/`
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed — not applicable

### Examples
- [x] `examples/` are added or updated for any new spec constructs — `multi_model_ai_context.yaml` added; `tpcds_semantic_model.yaml` intentionally left unchanged to demonstrate back-compat

### Tests
- [x] All existing tests pass (`pytest` / CI green) — `python/tests` 9 -> 12 passing; `validation/test_validate.py` 34 passing; `validation/tests/` 10 passing
- [x] New functionality is covered by tests — 3 new tests, including one pinning the core and ontology roots to the same `AIContext` definition

### Compliance
- [x] ASF license headers are present on all new source files — present on the new example
- [x] No third-party dependencies are added without PMC/IPMC approval — none added
