### PR TITLE
fix(dbt): compatibility with pydantic v1 results and fixing the semantic format of flights.yaml

### DIFF
--- a/converters/dbt/src/ossie_dbt/cli.py
+++ b/converters/dbt/src/ossie_dbt/cli.py
@@ -67,6 +67,22 @@ def _cmd_msi_to_osi(args: argparse.Namespace) -> None:
     print(f"Written to {output_path}", file=sys.stderr)
 
 
+def safe_model_dump(obj, **kwargs):
+    """兼容 Pydantic v1 和 v2 的序列化"""
+    if hasattr(obj, 'model_dump_json'):
+        return obj.model_dump_json(**kwargs)
+    elif hasattr(obj, 'json'):
+        return obj.json(**kwargs)
+    elif hasattr(obj, 'dict'):
+        # Pydantic v1 的 dict 方法
+        return json.dumps(obj.dict(**kwargs), indent=kwargs.get('indent', 2))
+    elif hasattr(obj, 'model_dump'):
+        # Pydantic v2 的 dict 方法
+        return json.dumps(obj.model_dump(**kwargs), indent=kwargs.get('indent', 2))
+    else:
+        # 尝试直接转字典
+        return json.dumps(obj.__dict__, indent=kwargs.get('indent', 2))
+    
 def _cmd_osi_to_msi(args: argparse.Namespace) -> None:
     input_path = Path(args.input)
     output_path = Path(args.output)
@@ -75,7 +91,13 @@ def _cmd_osi_to_msi(args: argparse.Namespace) -> None:
     document = OSIDocument.model_validate(raw)
     result = OSIToMSIConverter().convert(document)
 
-    output_path.write_text(result.output.model_dump_json(by_alias=True, exclude_none=True, indent=2))
+    json_output = safe_model_dump(
+        result.output, 
+        by_alias=True, 
+        exclude_none=True, 
+        indent=2
+)
+    output_path.write_text(json_output)
     print(f"Written to {output_path}", file=sys.stderr)
 
 

--- a/converters/dbt/src/ossie_dbt/cli.py
+++ b/converters/dbt/src/ossie_dbt/cli.py
@@ -68,19 +68,18 @@ def _cmd_msi_to_osi(args: argparse.Namespace) -> None:
 
 
 def safe_model_dump(obj, **kwargs):
-    """兼容 Pydantic v1 和 v2 的序列化"""
+    """compatible pydantic v1 和 v2"""
     if hasattr(obj, 'model_dump_json'):
         return obj.model_dump_json(**kwargs)
     elif hasattr(obj, 'json'):
         return obj.json(**kwargs)
     elif hasattr(obj, 'dict'):
-        # Pydantic v1 的 dict 方法
+        # Pydantic v1
         return json.dumps(obj.dict(**kwargs), indent=kwargs.get('indent', 2))
     elif hasattr(obj, 'model_dump'):
-        # Pydantic v2 的 dict 方法
+        # Pydantic v2
         return json.dumps(obj.model_dump(**kwargs), indent=kwargs.get('indent', 2))
     else:
-        # 尝试直接转字典
         return json.dumps(obj.__dict__, indent=kwargs.get('indent', 2))
     
 def _cmd_osi_to_msi(args: argparse.Namespace) -> None:

--- a/examples/flights.yaml
+++ b/examples/flights.yaml
@@ -537,10 +537,8 @@ ontology:
     - '{Route} connects to departure- {Airport}'    # The hyphen after "departure" has significance when verbalizing constraints
     multiplicity: ManyToOne                         # Each Route connects to at most one departure Airport
     requires: [ 'NOT Route.destination(Airport)' ]
-ontology_mappings:
-- name: flights_mapping
-  semantic_model:
-    name: Flights semantic model
+semantic_model:
+  - name: Flights semantic model
     datasets:
     - name: RUNWAY
       source: DATABASE.SCHEMA.RUNWAYS
@@ -821,6 +819,9 @@ ontology_mappings:
           dialects:
           - dialect: ANSI_SQL
             expression: name
+
+ontology_mappings:
+- name: flights_mapping
   concept_mappings:
   - concept: Runway
     object_mappings:


### PR DESCRIPTION


## Summary
run osi-to-msi command using following:
ossie-dbt osi-to-msi -i ../../examples/flights.yaml  -o semantic_manifest.json

2 exceptions occurred:

- exception 1:

```
Traceback (most recent call last):
  File "/Users/small/dev/venv/venv0/bin/ossie-dbt", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/small/dev/venv/venv0/lib/python3.12/site-packages/ossie_dbt/cli.py", line 104, in main
    _cmd_osi_to_msi(args)
  File "/Users/small/dev/venv/venv0/lib/python3.12/site-packages/ossie_dbt/cli.py", line 78, in _cmd_osi_to_msi
    output_path.write_text(result.output.model_dump_json(by_alias=True, exclude_none=True, indent=2))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PydanticSemanticManifest' object has no attribute 'model_dump_json'
```
cause:  msi_pydantic_shim.py use pydantic v1 format for v1 and v2 in https://github.com/dbt-labs/metricflow/blob/main/msi_pydantic_shim.py, pydantic v1  result don`t include model_dump_json, so it must be use v1

- exception 2:
```
  File "/Users/small/dev/venv/venv0/lib/python3.12/site-packages/ossie_dbt/cli.py", line 91, in _cmd_osi_to_msi
    document = OSIDocument.model_validate(raw)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/small/dev/venv/venv0/lib/python3.12/site-packages/pydantic/main.py", line 732, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for OSIDocument
semantic_model
  Field required [type=missing, input_value={'version': '0.2.0.dev0',...p': 'departure'}]}]}]}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/missing
```
cause: the ontology_mappings field does not meet the standard format in flights.yaml  , therefore it is occurred


## Related Issues


## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [x] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [x] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [ ] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [ ] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval