### PR TITLE
feat: register MICROSOFT as a well-known vendor token and reconcile the vendor lists

### DIFF
--- a/converters/README.md
+++ b/converters/README.md
@@ -65,7 +65,10 @@ Read a vendor-specific semantic model and produce a valid Ossie model, including
 
 ## Supported Vendors
 
-The Ossie specification currently defines extensions for the following vendors:
+The canonical list of well-known vendor tokens lives in
+[`core-spec/spec.md`](../core-spec/spec.md#vendor-names); the table below adds the
+converter-facing description of the source format. Add a vendor to both places, or to
+neither — they have drifted apart before.
 
 | Vendor | Description |
 |--------|-------------|
@@ -73,11 +76,20 @@ The Ossie specification currently defines extensions for the following vendors:
 | `SALESFORCE` | Salesforce / Tableau semantic layer |
 | `DBT` | dbt semantic models |
 | `DATABRICKS` | Databricks semantic layer |
+| `GOODDATA` | GoodData workspace / logical data model |
+| `HONEYDEW` | Honeydew semantic layer |
 | `OMNI` | Omni semantic model |
 | `WISDOM` | WisdomAI domain |
 | `NVIDIA_GSF` | NVIDIA Generative Semantic Fabric standalone YAML |
+| `MICROSOFT` | Microsoft Tabular model — Power BI, Fabric semantic models, Azure Analysis Services and SQL Server Analysis Services (TMSL `model.bim` / TMDL) |
 
-Each vendor may define custom extensions (via the `custom_extensions` field in the Ossie spec) to carry vendor-specific metadata that does not have an equivalent in the core specification.
+A token names the **organization**, not one of its products, so one token covers every
+product that shares the same underlying model. `SALESFORCE` already works this way for
+the Tableau semantic layer, and `MICROSOFT` works this way for the Tabular model that
+Power BI, Fabric, Azure Analysis Services and SQL Server Analysis Services all share.
+
+Each vendor may define custom extensions (via the `custom_extensions` field in the Ossie spec) to carry vendor-specific metadata that does not have an equivalent in the core specification. Vendors that need more than a table row document their payload under
+[`docs/vendor_extensions/`](../docs/vendor_extensions/).
 
 ## Mapping Core Constructs
 

--- a/core-spec/osi-schema.json
+++ b/core-spec/osi-schema.json
@@ -28,8 +28,8 @@
     },
     "Vendor": {
       "type": "string",
-      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA", "WISDOM"],
-      "description": "Vendor name for custom extensions. Any string value is accepted."
+      "examples": ["COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA", "HONEYDEW", "WISDOM", "OMNI", "NVIDIA_GSF", "MICROSOFT"],
+      "description": "Vendor name for custom extensions. Any string value is accepted. These examples are the well-known tokens documented in core-spec/spec.md; they are not an exhaustive or closed set."
     },
     "AIContext": {
       "description": "Additional context for AI tools",

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -434,7 +434,12 @@ custom_extensions:
 The `vendor_name` field is a free-form string, allowing any vendor or organization to
 define custom extensions without requiring changes to the core specification.
 
-The following are well-known examples:
+This table is the canonical list of well-known tokens. It is a registry of conventions,
+not a closed set: a `vendor_name` outside this table is valid and MUST be preserved by
+conforming tools. A token names the **organization** that defines the extension, not one
+of its products, so that a single token covers every product built on the same underlying
+model (see `SALESFORCE`, which covers the Tableau semantic layer, and `MICROSOFT`, which
+covers the Tabular model shared by Power BI, Fabric and Analysis Services).
 
 | Vendor | Description |
 |--------|-------------|
@@ -446,6 +451,9 @@ The following are well-known examples:
 | `GOODDATA` | GoodData-specific attributes |
 | `HONEYDEW` | Honeydew-specific attributes |
 | `WISDOM` | WisdomAI-specific attributes |
+| `OMNI` | Omni-specific attributes |
+| `NVIDIA_GSF` | NVIDIA Generative Semantic Fabric-specific attributes |
+| `MICROSOFT` | Microsoft Tabular model attributes — Power BI, Fabric semantic models, Azure Analysis Services and SQL Server Analysis Services (TMSL / TMDL / TOM). See [Microsoft vendor extension](../docs/vendor_extensions/microsoft.md). |
 
 ### Examples
 
@@ -488,12 +496,34 @@ The following are well-known examples:
 **Databricks Extension:**
 
 ```yaml
-- vendor_name: Databricks
+- vendor_name: DATABRICKS
   data: '{
     "default_catalog": "finance",
     "default_schema": "gold"
   }'
 ```
+
+**Microsoft Extension:**
+
+Carries the Tabular model properties that Ossie core cannot express. A measure's DAX
+itself belongs in the metric's `expression` under the `DAX` dialect, not here — the
+extension carries only what has no core equivalent.
+
+```yaml
+- vendor_name: MICROSOFT
+  data: '{
+    "_v": 1,
+    "format": "TMSL",
+    "formatString": "#,0.00",
+    "displayFolder": "Sales\\KPIs",
+    "isHidden": false,
+    "lineageTag": "9b1f6f3a-4c2e-4d2a-9c5a-1f8b2d0e7a41"
+  }'
+```
+
+See [Microsoft vendor extension](../docs/vendor_extensions/microsoft.md) for the full
+key set, including hierarchies, calculation groups, RLS/OLS roles, partitions and
+storage mode, and perspectives.
 
 ---
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -54,7 +54,9 @@ datatypes:
   - "Opaque"                # Known type outside the portable vocabulary
 
 # Vendor name for custom extensions (free-form string)
-# Examples: "COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA", "WISDOM"
+# Well-known examples (see "Vendor Names" in core-spec/spec.md for the canonical list):
+#   "COMMON", "SNOWFLAKE", "SALESFORCE", "DBT", "DATABRICKS", "GOODDATA", "HONEYDEW",
+#   "WISDOM", "OMNI", "NVIDIA_GSF", "MICROSOFT"
 vendor_name: string
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -343,6 +343,7 @@ A practical guide for organizations looking to adopt Ossie.
 - **TPC-DS Example Model**: [examples/tpcds_semantic_model.yaml](../examples/tpcds_semantic_model.yaml)
 - **Validation Script**: [validation/validate.py](../validation/validate.py)
 - **Converters Guide**: [converters/README.md](../converters/README.md)
+- **Vendor Extensions**: [docs/vendor_extensions/](vendor_extensions/) — per-vendor `custom_extensions` conventions
 
 ---
 

--- a/docs/vendor_extensions/microsoft.md
+++ b/docs/vendor_extensions/microsoft.md
@@ -136,6 +136,31 @@ Model-level constructs that have no Ossie object at all (roles, perspectives, cu
 shared expressions) live in the model-level payload, keyed by their TMSL collection
 name.
 
+### Which name space a value refers to
+
+Many payload values are *references* to other objects: `sortByColumn`, a hierarchy
+level's `column`, a role's `tablePermissions[].name`, a perspective's member lists.
+
+**Every such reference is a TMSL name, not an Ossie name.** The payload is TMSL
+fragments held verbatim, so its internal references must stay in TMSL's name space or
+the fragment stops being replayable. The two name spaces routinely differ: a converter
+may emit an Ossie field `month_name` for the TMSL column `MonthName`, and it is the
+latter that a `sortByColumn` names.
+
+Two rules follow, and the second is easy to get wrong:
+
+1. **Do not translate references into Ossie names.** A reference rewritten into the
+   Ossie name space no longer resolves against the model it will be replayed into.
+2. **Do not reference a Tabular object that has no Ossie object.** If a payload names a
+   column, that column must also be present as an ordinary field — otherwise the
+   reference dangles for every consumer that reads only core fields, and the construct
+   it supports (a sort order, a hierarchy level) silently loses its target. Preserving
+   a sort key *only* inside a payload is not preservation.
+
+This is why a column that exists purely to support another construct — a month-number
+sort key, a hierarchy's year column — is emitted as a normal field, usually with
+`isHidden: true` in its own payload, rather than left out as an implementation detail.
+
 ## Model level
 
 | Key | Construct | Why core cannot hold it |
@@ -211,7 +236,7 @@ The measure's DAX expression itself does **not** go here — see
 
 | Key | Construct |
 |---|---|
-| `isActive` | Whether the relationship participates in filter propagation by default. Ossie relationships have no inactive state; an inactive relationship recorded as an ordinary Ossie relationship would misrepresent the join graph. |
+| `isActive` | Whether the relationship participates in filter propagation by default. Ossie relationships have no inactive state, so this flag is written on **every** relationship, active ones included — a reader that finds no flag cannot otherwise distinguish "active" from "converted by a tool that dropped it". An inactive relationship must not be emitted as an ordinary Ossie relationship, because that asserts a join the engine does not apply by default; report it instead. |
 | `crossFilteringBehavior` | `oneDirection`, `bothDirections`, or `automatic`. |
 | `securityFilteringBehavior` | How row-level security filters propagate across the relationship. |
 | `fromCardinality`, `toCardinality` | `one`, `many`, or `none`. Records many-to-many, which Ossie cannot express, and records the original orientation when a converter flipped the endpoints to put the many side on `from`. |

--- a/docs/vendor_extensions/microsoft.md
+++ b/docs/vendor_extensions/microsoft.md
@@ -1,0 +1,411 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# `MICROSOFT` vendor extension
+
+This document defines what belongs in `custom_extensions` entries whose
+`vendor_name` is `MICROSOFT`. It is a convention, not a normative part of the core
+specification: `vendor_name` is a free-form string and this token is registered as a
+well-known example in [`core-spec/spec.md`](../../core-spec/spec.md#vendor-names).
+
+Everything below is reconstructible from public documentation. See
+[References](#references).
+
+## Why the token is `MICROSOFT` and not `POWER_BI`
+
+One object model — the Tabular model, scripted as **TMSL** (JSON, `model.bim`),
+authored as **TMDL** (text), and manipulated through the **Tabular Object Model
+(TOM)** — is the storage format for all of:
+
+- Power BI semantic models (Desktop and Service)
+- Microsoft Fabric semantic models
+- Azure Analysis Services (tabular)
+- SQL Server Analysis Services (tabular mode)
+
+A `model.bim` does not record which of these produced it, and a converter reading one
+cannot tell. A token named after a single product would therefore mislabel the other
+three. `MICROSOFT` is the only candidate token that is true for every input.
+
+This matches how Ossie already registers vendors: tokens name the **organization**
+(`SNOWFLAKE`, `DATABRICKS`, `GOODDATA`, `HONEYDEW`), and `SALESFORCE` already covers a
+differently-branded product — the Tableau semantic layer — under the company token.
+
+The cost of a company token is that it is broader than the payload: Microsoft ships
+semantic surfaces that are not Tabular models. That is handled explicitly by the
+`format` discriminator in the envelope below, rather than by minting a second vendor
+token. This is a deliberate choice of the recoverable error over the unrecoverable one
+— a payload that is too broadly labelled can be narrowed inside the envelope, whereas a
+token that is too narrow cannot be widened once it is written into files in the wild.
+
+**There is exactly one token.** `MICROSOFT` is canonical for both writing and reading.
+Writers MUST NOT emit `POWER_BI`, `FABRIC`, `SSAS`, `AAS` or any other alias. Readers
+MUST NOT accept aliases either: a reader that silently accepts two spellings makes it
+impossible to notice that a writer disagrees, and the first symptom is a lost round
+trip.
+
+## What the extension is *not* for
+
+The extension carries only what Ossie core cannot express. Anything with a core home
+goes in the core field, and duplicating it here creates two sources of truth that drift.
+
+In particular:
+
+| Tabular construct | Ossie core home — do **not** put it in the extension |
+|---|---|
+| Measure DAX expression | `metrics[].expression.dialects[]` with `dialect: DAX` |
+| Calculated column DAX | `fields[].expression.dialects[]` with `dialect: DAX` |
+| Column `sourceColumn` | `fields[].expression` (an `ANSI_SQL` plain column reference) |
+| Table | `datasets[]` |
+| Column | `datasets[].fields[]` |
+| Measure | `metrics[]` |
+| Column `dataType` | `fields[].datatype` |
+| Column `isKey` / `isUnique` | `datasets[].primary_key` / `.unique_keys` |
+| Relationship endpoints | `relationships[]` |
+| Object `description` | `description` |
+| Time-role column | `fields[].dimension.is_time` |
+
+> **Dialect dependency.** The `DAX` dialect member is added by
+> [apache/ossie#250](https://github.com/apache/ossie/pull/250). Until that lands,
+> `$defs.Dialect` has no `DAX` member and `validation/validate.py` will hand a DAX
+> expression to sqlglot as if it were SQL. This registration deliberately does not
+> duplicate #250's change; it assumes it and defers to it. See
+> [Sequencing](#sequencing).
+
+## Envelope
+
+`CustomExtension.data` is a **string** containing a JSON **object**.
+
+```json
+{
+  "_v": 1,
+  "format": "TMSL",
+  "<tmslPropertyName>": "<value>"
+}
+```
+
+| Key | Required | Meaning |
+|---|---|---|
+| `_v` | yes | Integer payload-format version. A reader that encounters a `_v` higher than it understands MUST fail loudly rather than interpret the payload, because a newer writer may have changed what an existing key means. |
+| `format` | recommended | Which Microsoft metadata surface this payload describes. `"TMSL"` is the only value defined here. A payload with no `format` key is `"TMSL"`, for compatibility with payloads written before the key existed. A reader that does not understand a `format` value MUST preserve the entry untouched and MUST NOT interpret its other keys. |
+
+Every other key is a **TMSL property name, spelled exactly as TMSL spells it**
+(camelCase, e.g. `formatString`, `displayFolder`, `crossFilteringBehavior`). No
+synonyms, no re-casing, no invented names — so any key in a payload can be looked up
+directly in the public TMSL reference. Values keep their TMSL shape and type.
+
+Two consequences worth stating:
+
+- **Preservation is a deny-list, not an allow-list.** A converter should carry across
+  every TMSL property it did not consume, including properties it has never heard of,
+  rather than only the ones enumerated below. New TMSL properties appear over time; an
+  allow-list turns each one into silent data loss.
+- **Preserved is not the same as modelled.** These constructs survive a round trip back
+  to a Tabular model, but they are opaque to every other Ossie consumer. A converter
+  should report them rather than let a user assume Ossie understood them.
+
+## Placement
+
+The extension is attached to the Ossie object that corresponds to the Tabular object,
+so the payload never has to re-state where it belongs.
+
+| Ossie object | Carries the leftovers of |
+|---|---|
+| `semantic_model[]` | `model`, plus anything database-level |
+| `semantic_model[].datasets[]` | `table` |
+| `semantic_model[].datasets[].fields[]` | `column` |
+| `semantic_model[].metrics[]` | `measure` |
+| `semantic_model[].relationships[]` | `relationship` |
+
+Model-level constructs that have no Ossie object at all (roles, perspectives, cultures,
+shared expressions) live in the model-level payload, keyed by their TMSL collection
+name.
+
+## Model level
+
+| Key | Construct | Why core cannot hold it |
+|---|---|---|
+| `compatibilityLevel` | Database compatibility level (e.g. `1550`, `1600`). Gates which constructs the model may use — calculation groups and Direct Lake each require a minimum level. | No versioning concept in Ossie. |
+| `defaultMode` | Default storage mode for partitions that do not state one. | See *Partitions and storage mode*. |
+| `directLakeBehavior` | `automatic`, `directLakeOnly`, or `directQueryOnly` — what the engine does when a Direct Lake query cannot be served from the delta tables. | Execution policy, not structure. |
+| `culture`, `sourceQueryCulture`, `collation` | Model locale and collation. Affects how format strings and sorting are interpreted. | No locale concept. |
+| `discourageImplicitMeasures` | Whether report clients may build implicit aggregations over columns. Required to be `true` for calculation groups. | No client-behaviour concept. |
+| `defaultPowerBIDataSourceVersion` | Which data-source generation the model uses. | Physical binding detail. |
+| `roles` | Row-level and object-level security. See *Security roles*. | Ossie has no security model. |
+| `perspectives` | Named subsets of the model. See *Perspectives*. | No subsetting concept. |
+| `cultures` | Translations (captions, descriptions, display folders) and the linguistic schema used by Q&A. | Ossie objects have a single name. |
+| `expressions` | Shared Power Query (M) expressions and parameters referenced by partitions. | Not a semantic construct. |
+| `queryGroups` | Authoring folders for Power Query queries. | Authoring-tool organization. |
+| `dataSources` | Legacy data source definitions. | Physical connection detail. |
+| `annotations` | Arbitrary `name`/`value` pairs written by tools. Present on every Tabular object, not only the model. | Free-form tool metadata. |
+
+## Dataset (table) level
+
+| Key | Construct |
+|---|---|
+| `isHidden` | Table hidden from report clients. Visibility, not structure — a hidden table is still queryable by name. |
+| `isPrivate` | Table hidden from *all* clients, typically an implementation detail of another construct. |
+| `dataCategory` | Semantic role hint, e.g. `Time` for a date table. |
+| `excludeFromModelRefresh` | Table skipped by refresh. |
+| `partitions` | See *Partitions and storage mode*. |
+| `hierarchies` | See *Hierarchies*. |
+| `calculationGroup` | See *Calculation groups*. |
+| `refreshPolicy` | Incremental refresh policy: rolling window, incremental granularity, and the `policyRange` partitions the engine generates from it. |
+| `alternateOf` | Aggregation table mapping onto a detail table. |
+| `defaultDetailRowsDefinition` | DAX table expression returning the rows behind an aggregate. |
+| `lineageTag`, `sourceLineageTag` | See *Lineage tags*. |
+| `annotations` | Tool metadata. |
+
+## Field (column) level
+
+| Key | Construct |
+|---|---|
+| `formatString` | See *Format strings*. |
+| `displayFolder` | See *Display folders*. |
+| `isHidden` | See *Visibility*. |
+| `summarizeBy` | Default aggregation a report client applies when the column is dropped on a visual (`sum`, `average`, `count`, `none`, …). Ossie models explicit metrics, not client defaults. |
+| `sortByColumn` | Another column in the same table that supplies the sort order — the standard "sort month name by month number" construct. Lost sorting is invisible until a chart is drawn in the wrong order. |
+| `dataCategory` | Semantic role hint, e.g. `Address`, `WebUrl`, `Latitude`, `ImageUrl`. |
+| `type` | Column kind: `data`, `calculated`, `calculatedTableColumn`, or `rowNumber`. |
+| `dataType` | Retain when the TMSL type has no portable Ossie equivalent (`binary`, `variant`) or is unresolved (`automatic`, `unknown`), so export restores the original rather than guessing from the portable type. |
+| `isNullable`, `isDefaultLabel`, `isDefaultImage`, `isAvailableInMdx` | Nullability and client-behaviour flags. |
+| `encodingHint` | Storage encoding hint (`value`, `hash`, `default`). |
+| `variations` | Date-table variations that let a column navigate to a date table. |
+| `lineageTag`, `sourceLineageTag` | See *Lineage tags*. |
+| `annotations` | Tool metadata. |
+
+## Metric (measure) level
+
+| Key | Construct |
+|---|---|
+| `formatString` | See *Format strings*. |
+| `formatStringDefinition` | A **dynamic** format string: a DAX expression evaluated per cell that returns the format to use. |
+| `displayFolder` | See *Display folders*. |
+| `isHidden` | See *Visibility*. |
+| `dataCategory` | Semantic role hint. |
+| `kpi` | KPI wrapper: target expression, status expression and graphic. |
+| `detailRowsDefinition` | DAX table expression returning the rows behind the aggregate. |
+| `dataType` | The engine-inferred return type, when Ossie's `datatype` cannot express it. |
+| `lineageTag`, `sourceLineageTag` | See *Lineage tags*. |
+| `annotations` | Tool metadata. |
+
+The measure's DAX expression itself does **not** go here — see
+[What the extension is *not* for](#what-the-extension-is-not-for).
+
+## Relationship level
+
+| Key | Construct |
+|---|---|
+| `isActive` | Whether the relationship participates in filter propagation by default. Ossie relationships have no inactive state; an inactive relationship recorded as an ordinary Ossie relationship would misrepresent the join graph. |
+| `crossFilteringBehavior` | `oneDirection`, `bothDirections`, or `automatic`. |
+| `securityFilteringBehavior` | How row-level security filters propagate across the relationship. |
+| `fromCardinality`, `toCardinality` | `one`, `many`, or `none`. Records many-to-many, which Ossie cannot express, and records the original orientation when a converter flipped the endpoints to put the many side on `from`. |
+| `joinOnDateBehavior` | How a date/time join treats the time part. |
+| `relyOnReferentialIntegrity` | Permits the engine to assume referential integrity for DirectQuery join elimination. |
+| `lineageTag` | See *Lineage tags*. |
+
+## Constructs in detail
+
+### DAX expressions
+
+A measure is DAX and only DAX. It belongs in the metric's `expression` under the `DAX`
+dialect added by [#250](https://github.com/apache/ossie/pull/250):
+
+```yaml
+metrics:
+  - name: Sales Amount
+    expression:
+      dialects:
+        - dialect: DAX
+          expression: SUM('Sales'[Extended Amount])
+```
+
+A metric MAY additionally carry an `ANSI_SQL` dialect when a portable equivalent
+genuinely exists, and consumers pick a dialect per
+[`core-spec/expression_language.md`](../../core-spec/expression_language.md).
+
+Two rules keep this honest, and both matter more than they look:
+
+1. **Never machine-translate between DAX and SQL and present the result as authored.**
+   DAX aggregates resolve against a filter context with no SQL equivalent. A partial
+   rewrite produces a model that loads, refreshes and returns a number — the wrong one.
+   A missing metric is noticed; a plausible wrong one is not.
+2. **A calculated column is not a measure.** A calculated column evaluates in row
+   context, so an expression that is correct as a measure (`SUM('T'[X])`) returns the
+   whole-column total on every row when used as a column.
+
+### Format strings
+
+`formatString` is a Microsoft custom format string (the VBA-derived syntax, plus the
+named forms such as `Short Date` and `Currency`). It is the only place a Tabular model
+records **date-only intent**: the `dataType` vocabulary has no date-only, time-only or
+timezone-aware member, so every temporal value is stored as `dateTime` and a date-only
+column is one whose format string has no time-of-day tokens.
+
+A consumer that drops the format string therefore does not just lose presentation — it
+loses the distinction between Ossie's `Date` and `DateTime`.
+
+`formatStringDefinition` (on measures and calculation items) is a DAX expression
+producing the format per cell, and takes precedence over the static `formatString`.
+
+### Display folders
+
+`displayFolder` groups columns, measures and hierarchies in the field list. Nesting uses
+a backslash (`Sales\KPIs`), and an object can appear in several folders. It is purely
+organizational, but for a large model it is most of what makes the field list navigable,
+so dropping it is a real usability loss even though nothing computes differently.
+
+Note that in JSON a nested folder is written with an escaped backslash: `"Sales\\KPIs"`.
+
+### Visibility
+
+`isHidden` marks an object as hidden from report clients. Hidden is **not** private and
+not secured: a hidden column is still fully queryable by name, and hiding it is a
+curation signal, not access control. Ossie has no visibility concept, so an AI consumer
+reading an Ossie document sees a hidden surrogate key exactly as it sees a curated
+business column unless this flag is preserved and surfaced.
+
+Table-level `isPrivate` is stronger — hidden from all clients — and generally marks an
+implementation detail such as an auto-generated date table.
+
+### Hierarchies
+
+A `hierarchy` is an ordered navigation path over columns of one table (`Year` →
+`Quarter` → `Month` → `Date`), each `level` carrying `name`, `ordinal` and `column`,
+with its own `isHidden`, `displayFolder` and lineage tags. Ossie has no ordered
+drill path, and the ordering is the entire content of the construct — a set of the same
+columns is not the same thing.
+
+### Calculation groups
+
+A `calculationGroup` on a table replaces its columns with `calculationItems`, each a
+named DAX expression that **rewrites** the measure in scope via `SELECTEDMEASURE()` —
+the standard way to express time intelligence (`YTD`, `PY`, `YoY %`) once instead of
+per measure. An item may carry its own `formatStringDefinition`, and the group carries a
+`precedence` that orders it against other calculation groups.
+
+There is no Ossie equivalent, and there is no faithful expansion either: a calculation
+group is a *transformation over metrics*, not a metric. Preserve the whole
+`calculationGroup` object, and note that the containing table is not a dataset in the
+ordinary sense. Calculation groups require `discourageImplicitMeasures: true` on the
+model and a sufficient `compatibilityLevel`.
+
+### Security roles
+
+`roles` holds `ModelRole` objects. Each carries a `modelPermission`
+(`none`, `read`, `readRefresh`, `refresh`, `administrator`), optional `members`, and
+`tablePermissions`:
+
+- **RLS** — `tablePermissions[].filterExpression` is a DAX boolean expression filtering
+  the table's rows for members of the role.
+- **OLS** — `tablePermissions[].columnPermissions[].metadataPermission` of `none` hides
+  a column's *existence* from members of the role.
+
+Ossie has no security model at all. Two things follow, and both should be said out loud
+to anyone building on this:
+
+- A document converted from a secured model describes the **unsecured** shape. It is not
+  a security boundary and must not be treated as one.
+- OLS in particular means the model a given user sees is not the model in the document.
+
+Role membership may name identities. Whether membership should be preserved at all, or
+dropped as unnecessary personal data, is an open question — see below.
+
+### Partitions and storage mode
+
+`partitions` on a table each carry a `mode` and a `source`:
+
+| `mode` | Behaviour |
+|---|---|
+| `import` | Data is loaded into the in-memory engine at refresh. |
+| `directQuery` | Queries are pushed to the source at query time. |
+| `dual` | The engine chooses per query. |
+| `directLake` | Delta tables in OneLake are read directly, with no import step. |
+| `push` | Rows are pushed in through the API. |
+
+Source types include `m` (Power Query), `query` (native query against a data source),
+`entity` (a table in a Direct Lake or dataflow source), `calculated` (a DAX calculated
+table), `calculationGroup`, and `policyRange` (a partition generated by an incremental
+refresh policy).
+
+The mode is not presentation. It determines whether the model holds data or delegates,
+which functions are available, and what a refresh means. Ossie's `dataset.source` is a
+single string naming the underlying table or query, so the mode, the partitioning scheme
+and multi-partition tables all have to be preserved here.
+
+### Perspectives
+
+A `perspective` is a named subset of tables, columns, measures and hierarchies — a lens
+for a report author or an AI consumer, not a security boundary (everything outside a
+perspective remains queryable). Ossie documents the whole model, so perspectives are the
+only record that a curated subset was intended.
+
+### Lineage tags
+
+`lineageTag` is a stable GUID identifying an object across edits, and `sourceLineageTag`
+identifies the corresponding object in the upstream source. They are what let TMDL
+diffing, Git integration and Direct Lake source mapping recognise a renamed object as
+the same object.
+
+They are the least interesting keys to read and among the most damaging to drop: a round
+trip that loses lineage tags turns every rename into a delete plus an add.
+
+## Round-trip rules
+
+1. **One token, one entry.** At most one `MICROSOFT` entry per Ossie object. A writer
+   that finds an existing entry merges into it rather than appending a second.
+2. **Preserve foreign entries.** Other vendors' `custom_extensions` are not
+   interpretable and MUST be carried through untouched.
+3. **Omit when empty.** A Tabular model that uses no Microsoft-specific construct
+   converts to clean, vendor-neutral Ossie with no `MICROSOFT` entry at all. An entry
+   containing only `_v` and `format` is noise.
+4. **Refuse, don't guess.** Malformed JSON, a non-object payload, a non-integer `_v`, a
+   `_v` from the future, or an unknown `format` are all errors or explicit
+   pass-throughs, never best-effort interpretation.
+
+## Sequencing
+
+This registration is intentionally decoupled from the converter implementation and from
+the `DAX` dialect:
+
+- The vendor token and these conventions stand on their own and can merge in any order
+  relative to [#250](https://github.com/apache/ossie/pull/250).
+- The `DAX` dialect member in `$defs.Dialect`, the `DAX` row in the spec's dialect table
+  and the `DAX` entry in `validation/validate.py`'s skip list all come from #250 and are
+  **not** duplicated here.
+- Until #250 merges, an Ossie document that uses `dialect: DAX` fails schema validation
+  (the enum has no such member) and, if it passed, would be handed to sqlglot as SQL.
+  Simple DAX happens to parse as SQL; realistic DAX (`VAR` / `RETURN`) does not. This is
+  why [`examples/microsoft_extension.yaml`](../../examples/microsoft_extension.yaml)
+  carries no DAX expression yet.
+
+## References
+
+All public:
+
+- [Tabular Model Scripting Language (TMSL) reference](https://learn.microsoft.com/analysis-services/tmsl/tabular-model-scripting-language-tmsl-reference)
+- [Tabular Model Definition Language (TMDL)](https://learn.microsoft.com/analysis-services/tmdl/tmdl-overview)
+- [Tabular Object Model (TOM)](https://learn.microsoft.com/analysis-services/tom/introduction-to-the-tabular-object-model-tom-in-analysis-services-amo)
+- [Tabular model compatibility levels](https://learn.microsoft.com/analysis-services/tabular-models/compatibility-level-for-tabular-models-in-analysis-services)
+- [Data Analysis Expressions (DAX) reference](https://learn.microsoft.com/dax/)
+- [Calculation groups](https://learn.microsoft.com/analysis-services/tabular-models/calculation-groups)
+- [Row-level security (RLS) with Power BI](https://learn.microsoft.com/power-bi/enterprise/service-admin-rls)
+- [Object-level security (OLS)](https://learn.microsoft.com/analysis-services/tabular-models/object-level-security)
+- [Direct Lake overview](https://learn.microsoft.com/fabric/fundamentals/direct-lake-overview)
+- [Semantic Link Labs](https://github.com/microsoft/semantic-link-labs) — a public
+  Python library that manipulates these same objects, useful as a worked reference.

--- a/examples/microsoft_extension.yaml
+++ b/examples/microsoft_extension.yaml
@@ -119,12 +119,48 @@ semantic_model:
             datatype: String
             custom_extensions:
               # Without sortByColumn, "April" sorts before "August" and every chart
-              # built on this column is silently in the wrong order.
+              # built on this column is silently in the wrong order. The value is the
+              # TMSL column name of month_number below, not its Ossie field name.
               - vendor_name: MICROSOFT
                 data: '{
                   "_v": 1,
                   "format": "TMSL",
                   "sortByColumn": "MonthNumber",
+                  "displayFolder": "Calendar"
+                }'
+          - name: month_number
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: MonthNumber
+            datatype: Integer
+            description: Sort order for month_name
+            custom_extensions:
+              # The target of the sortByColumn above. It has to exist as an ordinary
+              # field: a sort key that lives only inside a vendor payload has no Ossie
+              # representation, so the reference would dangle on the way back.
+              - vendor_name: MICROSOFT
+                data: '{
+                  "_v": 1,
+                  "format": "TMSL",
+                  "isHidden": true,
+                  "summarizeBy": "none",
+                  "displayFolder": "Calendar"
+                }'
+          - name: calendar_year
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: CalendarYear
+            datatype: Integer
+            dimension:
+              is_time: true
+            custom_extensions:
+              - vendor_name: MICROSOFT
+                data: '{
+                  "_v": 1,
+                  "format": "TMSL",
+                  "summarizeBy": "none",
                   "displayFolder": "Calendar"
                 }'
           - name: calendar_date
@@ -137,7 +173,9 @@ semantic_model:
               is_time: true
         custom_extensions:
           # dataCategory: Time marks the date table; the hierarchy is an ordered drill
-          # path, and the ordering is the whole content of the construct.
+          # path, and the ordering is the whole content of the construct. Every level
+          # names a TMSL column that is also an ordinary field above -- a level
+          # pointing at a column with no Ossie field would dangle.
           - vendor_name: MICROSOFT
             data: '{
               "_v": 1,
@@ -164,9 +202,14 @@ semantic_model:
         to_columns:
           - calendar_date
         custom_extensions:
-          # Ossie has no inactive-join concept. Recording an inactive relationship as an
-          # ordinary one would misrepresent the join graph, so the flag is preserved and
-          # the relationship reported.
+          # An ACTIVE relationship, whose flag is recorded anyway. Ossie has no
+          # inactive-join concept, so isActive is the only place the distinction can
+          # survive -- and a reader that finds no flag cannot tell "active" from
+          # "converted by a tool that dropped it".
+          #
+          # The inactive case deliberately does NOT appear here as an ordinary Ossie
+          # relationship: doing that would assert a join the engine does not apply by
+          # default. See docs/vendor_extensions/microsoft.md.
           - vendor_name: MICROSOFT
             data: '{
               "_v": 1,

--- a/examples/microsoft_extension.yaml
+++ b/examples/microsoft_extension.yaml
@@ -1,0 +1,223 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Worked example of the MICROSOFT vendor extension.
+#
+# The Microsoft Tabular model (TMSL / TMDL / TOM) backs Power BI semantic models,
+# Fabric semantic models, Azure Analysis Services and SQL Server Analysis Services.
+# Constructs that Ossie core can express are expressed in core fields; everything else
+# is preserved in a `MICROSOFT` custom_extensions entry, keyed by TMSL property name.
+#
+# See docs/vendor_extensions/microsoft.md for the full key catalogue.
+#
+# NOTE: metric expressions below use the ANSI_SQL dialect. A real Tabular measure is
+# DAX, and belongs in a `DAX` dialect entry — that enum member is added by
+# apache/ossie#250, so this example stays portable until #250 merges.
+
+version: 0.2.0.dev0
+semantic_model:
+  - name: sales_analytics
+    description: Sales analytics model imported from a Microsoft Tabular model
+    datasets:
+      - name: sales
+        source: Sales
+        description: Sales fact table
+        primary_key:
+          - sales_order_line_id
+        fields:
+          - name: sales_order_line_id
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: SalesOrderLineID
+            datatype: Integer
+            custom_extensions:
+              # A surrogate key: present and queryable, but curated out of the field
+              # list. Ossie has no visibility concept, so without this an AI consumer
+              # cannot tell it apart from a business column.
+              - vendor_name: MICROSOFT
+                data: '{
+                  "_v": 1,
+                  "format": "TMSL",
+                  "isHidden": true,
+                  "summarizeBy": "none",
+                  "lineageTag": "2f4a1c7e-8b3d-4e15-9a62-0d7c5b1e9f38"
+                }'
+          - name: extended_amount
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: ExtendedAmount
+            datatype: Decimal
+            description: Line item amount
+            custom_extensions:
+              - vendor_name: MICROSOFT
+                data: '{
+                  "_v": 1,
+                  "format": "TMSL",
+                  "formatString": "\\$#,0.00;(\\$#,0.00);\\$#,0.00",
+                  "displayFolder": "Amounts",
+                  "summarizeBy": "sum"
+                }'
+          - name: order_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: OrderDate
+            datatype: Date
+            dimension:
+              is_time: true
+        custom_extensions:
+          # A Direct Lake table. `dataset.source` is a single name, so the storage mode
+          # and the partition shape have nowhere else to live — and the mode decides
+          # whether the model holds data or delegates to OneLake at query time.
+          - vendor_name: MICROSOFT
+            data: '{
+              "_v": 1,
+              "format": "TMSL",
+              "partitions": [
+                {
+                  "name": "Sales",
+                  "mode": "directLake",
+                  "source": {"type": "entity", "entityName": "Sales", "schemaName": "dbo"}
+                }
+              ],
+              "lineageTag": "6c0b9d24-3f77-4a51-b8ee-2a9d4c6f1b03"
+            }'
+
+      - name: date
+        source: Date
+        description: Date dimension
+        primary_key:
+          - date_key
+        fields:
+          - name: date_key
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: DateKey
+            datatype: Integer
+          - name: month_name
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: MonthName
+            datatype: String
+            custom_extensions:
+              # Without sortByColumn, "April" sorts before "August" and every chart
+              # built on this column is silently in the wrong order.
+              - vendor_name: MICROSOFT
+                data: '{
+                  "_v": 1,
+                  "format": "TMSL",
+                  "sortByColumn": "MonthNumber",
+                  "displayFolder": "Calendar"
+                }'
+          - name: calendar_date
+            expression:
+              dialects:
+                - dialect: ANSI_SQL
+                  expression: CalendarDate
+            datatype: Date
+            dimension:
+              is_time: true
+        custom_extensions:
+          # dataCategory: Time marks the date table; the hierarchy is an ordered drill
+          # path, and the ordering is the whole content of the construct.
+          - vendor_name: MICROSOFT
+            data: '{
+              "_v": 1,
+              "format": "TMSL",
+              "dataCategory": "Time",
+              "hierarchies": [
+                {
+                  "name": "Calendar",
+                  "levels": [
+                    {"name": "Year", "ordinal": 0, "column": "CalendarYear"},
+                    {"name": "Month", "ordinal": 1, "column": "MonthName"},
+                    {"name": "Date", "ordinal": 2, "column": "CalendarDate"}
+                  ]
+                }
+              ]
+            }'
+
+    relationships:
+      - name: sales_to_date
+        from: sales
+        to: date
+        from_columns:
+          - order_date
+        to_columns:
+          - calendar_date
+        custom_extensions:
+          # Ossie has no inactive-join concept. Recording an inactive relationship as an
+          # ordinary one would misrepresent the join graph, so the flag is preserved and
+          # the relationship reported.
+          - vendor_name: MICROSOFT
+            data: '{
+              "_v": 1,
+              "format": "TMSL",
+              "isActive": true,
+              "crossFilteringBehavior": "oneDirection",
+              "fromCardinality": "many",
+              "toCardinality": "one"
+            }'
+
+    metrics:
+      - name: sales_amount
+        description: Total sales revenue
+        datatype: Decimal
+        expression:
+          dialects:
+            - dialect: ANSI_SQL
+              expression: SUM(sales.extended_amount)
+        custom_extensions:
+          - vendor_name: MICROSOFT
+            data: '{
+              "_v": 1,
+              "format": "TMSL",
+              "formatString": "\\$#,0.00;(\\$#,0.00);\\$#,0.00",
+              "displayFolder": "Sales\\KPIs",
+              "isHidden": false,
+              "lineageTag": "9b1f6f3a-4c2e-4d2a-9c5a-1f8b2d0e7a41"
+            }'
+
+    custom_extensions:
+      # Model-level leftovers, including the constructs that have no Ossie object at
+      # all. Roles are recorded so that a consumer knows the source model was secured —
+      # an Ossie document describes the UNSECURED shape and is not a security boundary.
+      - vendor_name: MICROSOFT
+        data: '{
+          "_v": 1,
+          "format": "TMSL",
+          "compatibilityLevel": 1604,
+          "culture": "en-US",
+          "discourageImplicitMeasures": true,
+          "directLakeBehavior": "automatic",
+          "roles": [
+            {
+              "name": "RegionalManager",
+              "modelPermission": "read",
+              "tablePermissions": [
+                {"name": "Sales", "filterExpression": "Sales[Region] = USERPRINCIPALNAME()"}
+              ]
+            }
+          ],
+          "perspectives": [
+            {"name": "Executive", "tables": [{"name": "Sales"}, {"name": "Date"}]}
+          ]
+        }'

--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -60,7 +60,12 @@ _TEMPORAL_DATA_TYPES = frozenset(
 
 
 class OSIVendor(str, Enum):
-    """Well-known vendor names for custom extensions."""
+    """Well-known vendor names for custom extensions.
+
+    Advisory only: ``OSICustomExtension.vendor_name`` is a free-form ``str``, so a
+    vendor outside this enum is valid. Keep in sync with the "Vendor Names" table in
+    ``core-spec/spec.md``, which is the canonical list.
+    """
 
     COMMON = "COMMON"
     SNOWFLAKE = "SNOWFLAKE"
@@ -68,8 +73,12 @@ class OSIVendor(str, Enum):
     DBT = "DBT"
     DATABRICKS = "DATABRICKS"
     GOODDATA = "GOODDATA"
+    HONEYDEW = "HONEYDEW"
     SEMANTIDO = "SEMANTIDO"
     WISDOM = "WISDOM"
+    OMNI = "OMNI"
+    NVIDIA_GSF = "NVIDIA_GSF"
+    MICROSOFT = "MICROSOFT"
 
 
 class OSIAIContextObject(BaseModel):


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Registers the Microsoft Tabular model (TMSL / TMDL / TOM) as a well-known `custom_extensions` vendor, so Power BI and Fabric semantic models can be a first-class spoke in the hub-and-spoke converter ecosystem.

This is the **registration slice only** — no converter implementation. It is deliberately small so the naming question can be settled before code depends on the answer.

### The token is `MICROSOFT`, not `POWER_BI`

There are currently two tokens in flight for the same vendor: #250 adds `MICROSOFT` to `Vendor.examples`, while work in progress elsewhere uses `POWER_BI` in the converters table. If both land, the spec ships contradictory guidance and `custom_extensions` written by one tool are silently invisible to the other.

This PR settles it on `MICROSOFT`, agreeing with #250:

1. **One object model, four products.** The Tabular model — scripted as TMSL, authored as TMDL, manipulated through TOM — is the storage format for Power BI semantic models, Fabric semantic models, Azure Analysis Services *and* SQL Server Analysis Services. A `model.bim` does not record which produced it, and a converter reading one cannot tell. A product-named token is therefore wrong for three of the four inputs.
2. **It matches existing precedent.** Ossie tokens name the organization — `SNOWFLAKE`, `DATABRICKS`, `GOODDATA`, `HONEYDEW` — and `SALESFORCE` already covers a differently-branded product, the Tableau semantic layer.
3. **It costs no renames.** #299 is currently renaming the GSF converter directory and package to `nvidia` to match its token. Under `MICROSOFT` a `converters/microsoft/` directory and an `ossie_microsoft` package already agree; under `POWER_BI` they would need exactly the churn #299 is doing.

The honest objection to a company token is that it over-covers: Microsoft ships semantic surfaces that are not Tabular models. That is answered **inside the payload**, with a `format` discriminator in the envelope, rather than by minting a second vendor token. This picks the recoverable error over the unrecoverable one — a payload labelled too broadly can be narrowed within the envelope, whereas a token that is too narrow cannot be widened once it is written into files in the wild.

**"Register both" is explicitly rejected.** `MICROSOFT` is canonical for reading *and* writing, and readers must **not** accept `POWER_BI` as an alias. A converter that stashes under one token and reads the other loses data on round-trip, and a reader that quietly accepts two spellings makes a disagreeing writer undetectable — the first symptom would be a silently lost round trip.

### Reconciling the vendor lists

Five places enumerated well-known vendors, and **all five already disagreed with each other on `main`**. This PR reconciles them rather than appending to one:

| Location | Was missing | Now |
|---|---|---|
| `core-spec/spec.md` "Vendor Names" | `OMNI`, `NVIDIA_GSF` | canonical list, + `MICROSOFT` |
| `converters/README.md` "Supported Vendors" | `GOODDATA`, `HONEYDEW` | + `MICROSOFT`, and now points at the canonical list |
| `core-spec/osi-schema.json` `Vendor.examples` | `HONEYDEW`, `OMNI`, `NVIDIA_GSF` | + `MICROSOFT` |
| `core-spec/spec.yaml` comment | 4 tokens | resynced to the canonical list |
| `python/src/ossie/models.py` `OSIVendor` | `HONEYDEW`, `OMNI`, `NVIDIA_GSF` | + `MICROSOFT`, + docstring |

`core-spec/spec.md` is now named as the single canonical list, and the other four point at it, so they cannot silently drift apart again.

`vendor_name` remains a **free-form string**. Nothing here turns it into an enum — the schema keeps `{"type": "string", "examples": [...]}`, the description now says outright that the examples are not a closed set, and `OSICustomExtension.vendor_name` stays typed `str`. `OSIVendor` is documented as advisory.

### Drive-by fix

The `Custom Extensions` example block used `vendor_name: Databricks` — the only mixed-case token in a document that is SCREAMING_SNAKE throughout, and inconsistent with the `DATABRICKS` row in the table directly above it. Changed to `DATABRICKS`. Flagging it explicitly rather than burying it: it is a one-word docs change with no schema effect (`vendor_name` is free-form, so both were always valid), but it is a change to a published example.

### What gives the registration substance

`docs/vendor_extensions/microsoft.md` documents what actually belongs in `custom_extensions[MICROSOFT]` — otherwise a registration is just a table row. It covers the constructs Ossie core cannot express, per level (model / dataset / field / metric / relationship):

- DAX expressions (and where they *don't* go), format strings, display folders, `isHidden` visibility
- hierarchies, calculation groups, perspectives
- RLS and OLS roles
- partitions and storage mode — Import / DirectQuery / Dual / **Direct Lake**
- lineage tags, `sortByColumn`, `summarizeBy`, relationship cardinality and cross-filter behaviour

Design points worth reviewing:

- **Keys are TMSL property names spelled exactly as TMSL spells them.** No synonyms, no re-casing — so any key in a payload can be looked up directly in the public reference.
- **Preservation is a deny-list, not an allow-list.** A converter should carry across TMSL properties it has never heard of. New properties appear over time; an allow-list turns each one into silent data loss.
- **A `_v` version and a `format` discriminator** in the envelope, with "fail loudly, never guess" rules for both.
- **The extension carries only what has no core home.** A measure's DAX belongs in `metrics[].expression` under the `DAX` dialect, *not* in the extension. There is an explicit table of constructs that must stay in core fields, so the two cannot become competing sources of truth.
- **Security is called out as absent.** An Ossie document converted from a model with RLS/OLS describes the *unsecured* shape and must not be treated as a security boundary.

Everything in it is reconstructible from public documentation — learn.microsoft.com's TMSL/TMDL/TOM/DAX/Direct Lake references and the public `microsoft/semantic-link-labs` repository, all cited at the bottom of the file.

`examples/microsoft_extension.yaml` is a worked example covering model, dataset, field, metric and relationship placement.

## Relationship to #250

This PR **agrees with and depends on nothing from** #250, and the two can merge in either order.

- #250 adds `MICROSOFT` to `Vendor.examples`; this PR's `Vendor.examples` line is a strict superset of #250's, so the conflict is a trivial one-line rebase whichever lands first.
- The `DAX` dialect — `$defs.Dialect`, the spec dialect table, `OSIDialect`, and the `validate.py` skip list — comes entirely from #250 and is **not duplicated here**. `docs/vendor_extensions/microsoft.md` defers to #250 by reference.
- Because of that, `examples/microsoft_extension.yaml` deliberately carries **no `DAX` dialect entry** yet, so it validates on today's `main`. Once #250 lands, the DAX-dialect form documented in the vendor doc becomes usable.

Worth knowing while #250 is open: `validate.py` currently hands a `DAX` expression to sqlglot as if it were SQL. Simple DAX happens to parse — `CALCULATE(SUM('Sales'[Amount]), 'Date'[Year] = 2024)` is accepted — while realistic DAX using `VAR` / `RETURN` fails. #250's skip-list entry fixes this; noting it here as supporting evidence for that part of #250.

## Other overlapping PRs

- **#299** (GSF → NVIDIA rename) — no file overlap. Its directory/package rename is cited above as precedent for token choice.
- **#306** (converter/schema alignment) — also edits `python/src/ossie/models.py`, but removes `vendors: Optional[list[OSIVendor]]` from the root model, which is different lines from this change. `OSIVendor` remains an exported public enum, so both changes are compatible.
- **#313** (Honeydew rebrand) and **#288** (OSI → Ossie rename) — no logical overlap, but #288 touches 135 files, so rebase order matters mechanically.
- **#323** (root-level `ai_context` / `custom_extensions`) — no conflict; this PR deliberately places nothing at the document root.

## Open questions for reviewers

1. **`SEMANTIDO`** appears in `OSIVendor` and in no other list — not in the spec, the schema, or any converter. I left it untouched rather than guess. Someone who knows what it is should either document or remove it.
2. **RLS role membership can name identities.** Should a converter preserve `members`, or drop it as unnecessary personal data? The doc flags the question rather than deciding it.
3. **`ORIONBELT` and `POLARIS`** have converters in-repo but no registered vendor token.
4. **Is `docs/vendor_extensions/` the right home** for per-vendor payload conventions, or should this live under `core-spec/`? It is a new convention introduced by this PR.
5. **Should `converters/README.md` keep its own vendor table at all**, or just link the canonical one? Two tables that must agree is what caused the current drift.

## Related Issues

Relates to #250.

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue — **not yet done.** Per `CONTRIBUTING.md`, changes touching `core-spec/` need a `dev@ossie.apache.org` thread and a minimum 7-day discussion period. This PR is opened to give that discussion something concrete to point at; the dev@ announcement still needs to be sent before it can merge.
- [x] Breaking changes to the spec are clearly called out in the summary — there are none. Adding examples to a free-form string field and adding rows to a documentation table cannot invalidate an existing document.

### Ontology
- [x] Ontology changes in `ontology/` are consistent with spec changes — n/a, no ontology change.
- [x] New or modified terms are defined and documented

### Converters
- [x] Converter logic in `converters/` is updated to reflect spec or ontology changes — n/a by design; this is the registration slice only, no converter is added or changed.
- [x] New converters include tests under the converter's test directory — n/a, no new converter.

### Validation
- [x] Validation rules in `validation/` are updated if the spec changed — no change needed; `vendor_name` is free-form, so no validation rule keys off the token. (The `DAX` skip-list entry belongs to #250.)
- [x] New validation cases are covered by tests

### Documentation
- [x] `docs/` is updated to reflect any user-facing changes
- [x] New features or behaviors are documented with examples where appropriate
- [x] `CONTRIBUTING.md` is updated if the contribution process changed — n/a, unchanged.

### Examples
- [x] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass — `python validation/validate.py` passes on `examples/microsoft_extension.yaml`, `examples/tpcds_semantic_model.yaml` and `examples/flights.yaml`; `pytest python/tests` is 9 passed.
- [x] New functionality is covered by tests — the new example is exercised by the validator.

### Compliance
- [x] ASF license headers are present on all new source files — both new files carry the standard header.
- [x] No third-party dependencies are added without PMC/IPMC approval — none added.
