### PR TITLE
Warn when relationship to_columns does not cover a declared key

### DIFF
--- a/validation/tests/test_validate.py
+++ b/validation/tests/test_validate.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+# validate.py exits at import time when its dependencies are missing, which
+# would abort the whole pytest session during collection — skip instead.
+pytest.importorskip("yaml")
+pytest.importorskip("jsonschema")
+
+_VALIDATE_PATH = Path(__file__).parents[1] / "validate.py"
+_SPEC = spec_from_file_location("ossie_validate", _VALIDATE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_VALIDATE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_VALIDATE)
+
+validate_references = _VALIDATE.validate_references
+
+
+def _document(datasets: list[dict], relationships: list[dict]) -> dict:
+    return {
+        "version": "0.2.0.dev0",
+        "semantic_model": [
+            {
+                "name": "m",
+                "datasets": datasets,
+                "relationships": relationships,
+            }
+        ],
+    }
+
+
+_CUSTOMERS = {
+    "name": "customers",
+    "source": "db.s.customers",
+    "primary_key": ["id"],
+    "unique_keys": [["email"]],
+}
+
+_ORDERS = {"name": "orders", "source": "db.s.orders"}
+
+
+def _relationship(to_columns: list[str], to: str = "customers") -> dict:
+    return {
+        "name": "orders_to_customers",
+        "from": "orders",
+        "to": to,
+        "from_columns": ["customer_id"],
+        "to_columns": to_columns,
+    }
+
+
+def test_warns_when_to_columns_does_not_cover_a_declared_key() -> None:
+    errors = validate_references(
+        _document([_ORDERS, _CUSTOMERS], [_relationship(to_columns=["region"])])
+    )
+
+    assert errors == [
+        "[Reference] Warning: Relationship 'orders_to_customers' in model 'm': "
+        "to_columns ['region'] does not cover the primary key or a unique key of dataset 'customers'"
+    ]
+
+
+def test_accepts_to_columns_matching_the_primary_key() -> None:
+    errors = validate_references(
+        _document([_ORDERS, _CUSTOMERS], [_relationship(to_columns=["id"])])
+    )
+
+    assert errors == []
+
+
+def test_accepts_to_columns_matching_a_unique_key() -> None:
+    errors = validate_references(
+        _document([_ORDERS, _CUSTOMERS], [_relationship(to_columns=["email"])])
+    )
+
+    assert errors == []
+
+
+def test_accepts_to_columns_that_is_a_superset_of_a_key() -> None:
+    # e.g. tenant-sharded joins carry extra columns on top of the key;
+    # coverage still guarantees the many-to-one semantics.
+    errors = validate_references(
+        _document([_ORDERS, _CUSTOMERS], [_relationship(to_columns=["tenant_id", "id"])])
+    )
+
+    assert errors == []
+
+
+def test_accepts_composite_key_regardless_of_column_order() -> None:
+    composite = {
+        "name": "order_lines",
+        "source": "db.s.order_lines",
+        "primary_key": ["order_id", "line_number"],
+    }
+    rel = _relationship(to_columns=["line_number", "order_id"], to="order_lines")
+
+    assert validate_references(_document([_ORDERS, composite], [rel])) == []
+
+
+def test_skips_datasets_that_declare_no_keys() -> None:
+    no_keys = {"name": "raw_table", "source": "db.s.raw_table"}
+    rel = _relationship(to_columns=["anything"], to="raw_table")
+
+    assert validate_references(_document([_ORDERS, no_keys], [rel])) == []
+
+
+def test_still_reports_unknown_datasets() -> None:
+    errors = validate_references(
+        _document([_ORDERS], [_relationship(to_columns=["id"], to="nope")])
+    )
+
+    assert errors == [
+        "[Reference] Relationship 'orders_to_customers' in model 'm' references unknown dataset 'nope'"
+    ]
+
+
+def test_tolerates_null_unique_keys() -> None:
+    # `unique_keys:` present but empty parses to None; the check must not crash.
+    dataset = {"name": "customers", "source": "db.s.customers",
+               "primary_key": ["id"], "unique_keys": None}
+    errors = validate_references(
+        _document([_ORDERS, dataset], [_relationship(to_columns=["id"])])
+    )
+
+    assert errors == []
+
+
+def test_skips_non_list_to_columns() -> None:
+    # Schema validation reports the shape error; the semantic check must
+    # neither crash nor emit a misleading character-set comparison.
+    rel = _relationship(to_columns=["id"])
+    rel["to_columns"] = "id"
+
+    assert validate_references(_document([_ORDERS, _CUSTOMERS], [rel])) == []
+
+
+def test_skips_malformed_flat_unique_keys() -> None:
+    # unique_keys mistakenly written flat like primary_key: strings are not
+    # keys, so with no well-formed key declared the check does not fire.
+    dataset = {"name": "customers", "source": "db.s.customers", "unique_keys": ["email"]}
+    errors = validate_references(
+        _document([_ORDERS, dataset], [_relationship(to_columns=["email"])])
+    )
+
+    assert errors == []

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -129,22 +129,40 @@ def validate_unique_names(data: dict) -> list[str]:
 
 
 def validate_references(data: dict) -> list[str]:
-    """Validate that relationships reference existing datasets."""
+    """Validate that relationships reference existing datasets and that
+    to_columns covers a declared key of the 'to' dataset."""
     errors = []
 
     for model in data.get("semantic_model", []):
         model_name = model.get("name", "<unnamed>")
-        dataset_names = {d.get("name") for d in model.get("datasets", []) if d.get("name")}
+        datasets = {d.get("name"): d for d in model.get("datasets", []) if d.get("name")}
 
         for rel in model.get("relationships", []):
             rel_name = rel.get("name", "<unnamed>")
             from_ds = rel.get("from")
             to_ds = rel.get("to")
 
-            if from_ds and from_ds not in dataset_names:
+            if from_ds and from_ds not in datasets:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{from_ds}'")
-            if to_ds and to_ds not in dataset_names:
+            if to_ds and to_ds not in datasets:
                 errors.append(f"[Reference] Relationship '{rel_name}' in model '{model_name}' references unknown dataset '{to_ds}'")
+
+            # The spec defines to_columns as "Primary/unique key columns in the
+            # 'to' dataset". Coverage (superset of a key) still guarantees the
+            # many-to-one join, and declared keys may be incomplete since
+            # primary_key and unique_keys are optional — so accept any
+            # to_columns that covers a declared key, report a warning rather
+            # than an error, and skip datasets that declare no keys.
+            # Shape guards keep semantic checks from crashing on documents
+            # that already fail schema validation.
+            dataset = datasets.get(to_ds)
+            to_columns = rel.get("to_columns")
+            if dataset and isinstance(to_columns, list) and to_columns:
+                candidate_keys = [dataset.get("primary_key")] + list(dataset.get("unique_keys") or [])
+                declared_keys = [k for k in candidate_keys if isinstance(k, list) and k]
+                to_column_set = set(to_columns)
+                if declared_keys and not any(set(key) <= to_column_set for key in declared_keys):
+                    errors.append(f"[Reference] Warning: Relationship '{rel_name}' in model '{model_name}': to_columns {to_columns} does not cover the primary key or a unique key of dataset '{to_ds}'")
 
     return errors
 


### PR DESCRIPTION
## Summary

The spec defines `to_columns` as "Primary/unique key columns in the 'to' dataset" (core-spec/spec.md, osi-schema.json), but the validator only checks that the relationship's datasets exist. A relationship that joins to non-key columns silently breaks many-to-one semantics downstream — joins fan out, and consumers that trust the declared cardinality produce wrong results. #301 shows this class of document being produced in practice and rejected by downstream consumers; a validator-side check catches it at the document level regardless of which tool produced it.

`validate_references` now checks that `to_columns` covers the `to` dataset's `primary_key` or one of its `unique_keys`. Two deliberate softenings, both drawn from how the repo already treats this rule:

- Coverage rather than exact equality: a `to_columns` that is a superset of a key still guarantees the join cardinality (tenant-sharded joins are a common shape), and the Databricks converter's `_covers_unique_key` already applies exactly these semantics.
- Warning rather than error: declared keys can be a partial recovery of the dataset's real keys (the Databricks importer, for instance, records `unique_keys` from a single join's `rely` hint), so a non-covering `to_columns` is suspicious but not provably wrong. The message goes through the validator's existing warning channel and does not fail validation. Happy to tighten this to an error if you'd rather trust key declarations as exhaustive.

Datasets that declare no keys are skipped — both `primary_key` and `unique_keys` are optional, so there is nothing to check against. The check also guards against shapes that already fail schema validation (null `unique_keys`, non-list `to_columns`, flat `unique_keys`) so the semantic pass can't crash or mislead on an invalid document.

Ran against every semantic-model YAML in the repo (examples plus converter fixtures): no regressions, all still pass. A relationship pointing at non-key columns now reports:

```
[Reference] Warning: Relationship 'orders_to_customers' in model 'm': to_columns ['region'] does not cover the primary key or a unique key of dataset 'customers'
```

A couple of adjacent gaps I noticed but left out of scope, flagging in case they're worth issues: no CI workflow currently runs `validation/tests` (this suite included), and the orionbelt converter's mirror validator (which documents itself as mirroring `validate.py`) doesn't have this rule — I can follow up on either. #307 (pending) adds from/to column count validation to the same function and introduces the same test file path; the checks are complementary and I'm happy to rebase if it lands first.

## Related Issues

Related to #301 (validator-side guard for the same class of invalid document; does not fix the converter itself).

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [x] Validation rules in `validation/` are updated if the spec changed
- [x] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval
