### PR TITLE
fix(dbt): use pydantic v1 .json() in ossie-to-msi

### DIFF
--- a/converters/dbt/src/ossie_dbt/cli.py
+++ b/converters/dbt/src/ossie_dbt/cli.py
@@ -75,7 +75,9 @@ def _cmd_osi_to_msi(args: argparse.Namespace) -> None:
     document = OSIDocument.model_validate(raw)
     result = OSIToMSIConverter().convert(document)
 
-    output_path.write_text(result.output.model_dump_json(by_alias=True, exclude_none=True, indent=2))
+    # PydanticSemanticManifest subclasses pydantic.v1.BaseModel, whose JSON
+    # serializer is .json(), not the pydantic v2 .model_dump_json().
+    output_path.write_text(result.output.json(by_alias=True, exclude_none=True, indent=2))
     print(f"Written to {output_path}", file=sys.stderr)
 
 

--- a/converters/dbt/src/ossie_dbt/cli.py
+++ b/converters/dbt/src/ossie_dbt/cli.py
@@ -74,7 +74,9 @@ def _cmd_ossie_to_msi(args: argparse.Namespace) -> None:
     document = OssieDocument.model_validate(raw)
     result = OssieToMSIConverter().convert(document)
 
-    output_path.write_text(result.output.model_dump_json(by_alias=True, exclude_none=True, indent=2))
+    # PydanticSemanticManifest subclasses pydantic.v1.BaseModel, whose JSON
+    # serializer is .json(), not the pydantic v2 .model_dump_json().
+    output_path.write_text(result.output.json(by_alias=True, exclude_none=True, indent=2))
     print(f"Written to {output_path}", file=sys.stderr)
 
 

--- a/converters/dbt/tests/test_cli.py
+++ b/converters/dbt/tests/test_cli.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""End-to-end tests for the ossie-dbt CLI entry point."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ossie_dbt import cli
+from tests.helpers import _osi_dataset, _osi_doc, _osi_field, _osi_metric
+
+
+def _run_cli(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["ossie-dbt", *argv])
+    cli.main()
+
+
+def test_osi_to_msi_writes_valid_manifest_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """osi-to-msi must serialize the manifest to JSON without crashing.
+
+    Regression test for the CLI calling the pydantic v2 ``.model_dump_json()``
+    on ``PydanticSemanticManifest``, which subclasses ``pydantic.v1.BaseModel``
+    and only exposes ``.json()``. Before the fix this raised ``AttributeError``
+    on every input, including the repository's own example model.
+    """
+    document = _osi_doc(
+        datasets=[
+            _osi_dataset(
+                name="orders",
+                fields=[_osi_field("order_id"), _osi_field("amount")],
+                primary_key=["order_id"],
+            )
+        ],
+        metrics=[_osi_metric("total_amount", "SUM(orders.amount)")],
+    )
+    input_path = tmp_path / "model.yaml"
+    output_path = tmp_path / "semantic_manifest.json"
+    input_path.write_text(document.to_osi_yaml())
+
+    _run_cli(["osi-to-msi", "-i", str(input_path), "-o", str(output_path)], monkeypatch)
+
+    assert output_path.exists()
+    manifest = json.loads(output_path.read_text())
+    assert "semantic_models" in manifest
+    assert "metrics" in manifest

--- a/converters/dbt/tests/test_cli.py
+++ b/converters/dbt/tests/test_cli.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""End-to-end tests for the ossie-dbt CLI entry point."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ossie_dbt import cli
+from tests.helpers import _ossie_dataset, _ossie_doc, _ossie_field, _ossie_metric
+
+
+def _run_cli(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.argv", ["ossie-dbt", *argv])
+    cli.main()
+
+
+def test_ossie_to_msi_writes_valid_manifest_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ossie-to-msi must serialize the manifest to JSON without crashing.
+
+    Regression test for the CLI calling the pydantic v2 ``.model_dump_json()``
+    on ``PydanticSemanticManifest``, which subclasses ``pydantic.v1.BaseModel``
+    and only exposes ``.json()``. Before the fix this raised ``AttributeError``
+    on every input, including the repository's own example model.
+    """
+    document = _ossie_doc(
+        datasets=[
+            _ossie_dataset(
+                name="orders",
+                fields=[_ossie_field("order_id"), _ossie_field("amount")],
+                primary_key=["order_id"],
+            )
+        ],
+        metrics=[_ossie_metric("total_amount", "SUM(orders.amount)")],
+    )
+    input_path = tmp_path / "model.yaml"
+    output_path = tmp_path / "semantic_manifest.json"
+    input_path.write_text(document.to_ossie_yaml())
+
+    _run_cli(["ossie-to-msi", "-i", str(input_path), "-o", str(output_path)], monkeypatch)
+
+    assert output_path.exists()
+    manifest = json.loads(output_path.read_text())
+    assert "semantic_models" in manifest
+    assert "metrics" in manifest


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

`ossie-dbt ossie-to-msi` fails on every input, including the repository's own
`examples/tpcds_semantic_model.yaml`, with:

```
AttributeError: 'PydanticSemanticManifest' object has no attribute 'model_dump_json'
```

`PydanticSemanticManifest` (from `metricflow_semantic_interfaces`) subclasses
`pydantic.v1.BaseModel`, whose JSON serializer is `.json()`, not the pydantic v2
`.model_dump_json()`. The conversion itself works — only the CLI's write step
was calling a v2-only method on a v1 object.

**Fix**

- `cli.py`: use `.json(by_alias=True, exclude_none=True, indent=2)`, which takes
  the same options on a pydantic v1 model and produces valid output.
- Add `tests/test_cli.py` — an end-to-end test that drives `ossie-to-msi` and
  asserts a valid semantic manifest is written. No test covered the CLI before,
  which is why CI stayed green through the crash.

**Verification**

```
cd converters/dbt
uv run pytest          # 101 passed (was 100)
uv run ossie-dbt ossie-to-msi -i ../../examples/tpcds_semantic_model.yaml -o /tmp/manifest.json
# -> Written to /tmp/manifest.json  (valid JSON)
```

The new test fails without the fix (`AttributeError`) and passes with it.

## Related Issues

Fixes #296

## Checklist

### Specification
_N/A — bug fix only, no spec change._

### Ontology
_N/A — no ontology change._

### Converters
- [x] New converters include tests under the converter's test directory

### Validation
_N/A — no validation change._

### Documentation
_N/A — no user-facing behavior change beyond the command no longer crashing._

### Examples
_N/A — no new spec constructs or converter support._

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval

