### PR TITLE
Updated schema to include top-level 'prefixes' property and 'Ontology Component.uri' property

### DIFF
--- a/ontology/ontology.json
+++ b/ontology/ontology.json
@@ -159,6 +159,10 @@
             "type": "string"
           },
           "description": "Natural language expressions that verbalize this relationship"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Optional global identifier for this relationship, expressed as a full URI or as a QName (prefix:local) resolved against the ontology-level 'prefixes' map."
         }
       },
       "required": ["name", "verbalizes"],

--- a/ontology/ontology.json
+++ b/ontology/ontology.json
@@ -42,6 +42,14 @@
       "items": {
         "$ref": "#/$defs/OntologyMap"
       }
+    },
+    "prefixes": {
+      "type": "object",
+      "description": "Maps namespace prefixes to the URIs they abbreviate, enabling QName expansion (e.g., 'foaf' -> 'http://xmlns.com/foaf/0.1/').",
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri"
+      }
     }
   },
   "required": ["version", "name", "ontology"],
@@ -96,6 +104,10 @@
             "$ref": "#/$defs/Relationship"
           },
           "description": "Defines relationships that pertain primarily to the concept defined in this component"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Optional global identifier for this concept, expressed as a full URI or as a QName (prefix:local) resolved against the ontology-level 'prefixes' map."
         }
       },
       "required": ["concept", "type"],


### PR DESCRIPTION
## Motivation

The Ossie Ontology Specification currently treats each model as a self-contained, stand-alone entity. Because all concept names are local to a model, there is no way to establish relationships or correspondences between models. This proposal adds an optional mechanism for assigning globally unique identifiers to concepts by adopting the Uniform Resource Identifier (URI) convention from the XML/RDF ecosystem.

To keep URIs concise and readable, this proposal also adopts the RDF/XML notion of namespace prefixes, allowing URIs to be written as compact QNames - e.g., `foaf:Agent` representing the URI `[http://xmlns.com/foaf/0.1/Agent`](http://xmlns.com/foaf/0.1/Agent).

Both additions are optional: models that do not need cross-model identity are unaffected and remain valid.

## Proposed Changes

This involves two changes to the current Ossie ontology Specification:

1) At the ontology level, create a `prefixes` property.
    Defines a mapping from a prefix to the namespace URI it abbreviates, enabling QName expansion throughout the model.
    Example: `foaf: http://xmlns.com/foaf/0.1/`

2) At the Concept level, create a `uri` property.
    Assigns a global identifier to a concept (`OntologyComponent`), expressed either as a full URI or as a QName resolved against the declared `prefixes`.
    Examples: `uri: foaf:Agent`, `uri: http://xmlns.com/foaf/0.1/Agent`

Here's an example using the proposed changes:

```
name: OrganizationOntology
ontology:
- prefixes:
   foaf: http://xmlns.com/foaf/0.1/
- concept: Agent
   type: EntityType
   description: "A generic agent (person, organization, etc.)"
   uri: foaf:Agent
   relationships:
    - name: AgentHasHomepage
      description: "Associates an Agent with its home page"
      multiplicity: OneToOne
      roles:
         - concept: AgentHomepage
      verbalizes: [ '{Agent} has {AgentHomepage}' ]

- concept: AgentHomepage
   type: ValueType
   description: "The home page of the agent"
   uri: http://xmlns.com/foaf/0.1/homepage
```

## Schema impact

Both properties are optional, so existing valid models remain valid (backward compatible). The changes affect two objects: