### PR TITLE
fix(cli): reject arguments to plugin list

### DIFF
--- a/cli/cmd/plugin/list.go
+++ b/cli/cmd/plugin/list.go
@@ -30,6 +30,7 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List installed plugins",
+	Args:  cobra.NoArgs,
 	// TODO(P1): cross-reference against the embedded plugin registry to show
 	// latest available versions and update indicators once registry embedding
 	// (F4) is implemented.

--- a/cli/cmd/plugin/list_test.go
+++ b/cli/cmd/plugin/list_test.go
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import "testing"
+
+func TestListArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name: "no arguments",
+		},
+		{
+			name:    "one argument",
+			args:    []string{"unexpected"},
+			wantErr: true,
+		},
+		{
+			name:    "multiple arguments",
+			args:    []string{"one", "two"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := listCmd.ValidateArgs(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateArgs(%q) error = %v, wantErr %v", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Reject unexpected positional arguments passed to `ossie plugin list` instead of silently ignoring them and returning success. Adds table-driven coverage for zero, one, and multiple arguments.

## Before

```console
$ ossie plugin list unexpected
no plugins installed
$ echo $?
0
```

Unexpected arguments were silently ignored.

## After

```console
$ ossie plugin list unexpected
Error: unknown command "unexpected" for "ossie plugin list"
$ echo $?
1
```

Unexpected arguments are rejected with a non-zero exit code.

## Related Issues

Closes #334

## Tests

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- Black-box verification that `ossie plugin list unexpected` exits with status 1

## Checklist

- [x] New behavior is covered by tests
- [x] All existing CLI tests pass
- [x] ASF license header is present on the new test file
- [x] No third-party dependencies were added