### PR TITLE
docs: clarify ICLA is only required at committer election, not for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,17 +81,21 @@ is being made):
 
 ## Contributor License Agreement (ICLA)
 
-All contributions to Apache Ossie are made under the [Apache License 2.0](LICENSE).
-By submitting a pull request or patch, you agree that your contribution is licensed
-under those terms (see Section 5 of the license).
+**No CLA is required to contribute.** All contributions to Apache Ossie are made under
+the [Apache License 2.0](LICENSE). By submitting a pull request or patch, you agree that
+your contribution is licensed under those terms (see Section 5 of the license). You can
+open issues, submit pull requests, and participate in discussions without signing
+anything.
 
-Before your first non-trivial contribution can be merged, and always before you are
-granted commit access, you must have an
-[Individual Contributor License Agreement (ICLA)](https://www.apache.org/licenses/contributor-agreements.html#clas)
-on file with the ASF. If you are contributing on behalf of your employer, a
+An [Individual Contributor License Agreement (ICLA)](https://www.apache.org/licenses/contributor-agreements.html#clas)
+is only required once you are elected as a committer: the ICLA must be on file with the
+ASF before your Apache account and commit access are set up. A
 [Corporate CLA (CCLA)](https://www.apache.org/licenses/contributor-agreements.html#clas)
-may also be required. Please keep individual commits signed off and attributed to
-the correct author so that provenance is clear.
+is likewise not required for contributions, and is only relevant for committers
+contributing on behalf of their employer.
+
+Please keep individual commits attributed to the correct author so that provenance is
+clear.
 
 ## AI-Assisted Contributions
 


### PR DESCRIPTION
## Summary

- Clarify that no CLA (ICLA or CCLA) is required to contribute to Apache Ossie
- An ICLA is only required once a contributor is elected as committer, before their Apache account and commit access are set up
- A CCLA is only relevant for committers contributing on behalf of their employer