### PR TITLE
docs(spec): align spec.yaml ai_context with the schema at every node

### DIFF
--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -171,6 +171,10 @@ relationships:
     #   - [order_id, line_number]    # Composite key
     to_columns: []  # Array of column names
 
+    # Optional: Additional context for AI tools (e.g., synonyms, business context)
+    # Helps LLMs understand when and why the datasets should be joined
+    ai_context: string
+
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
       - vendor_name: string  # Free-form string identifying the vendor

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -173,6 +173,11 @@ relationships:
 
     # Optional: Additional context for AI tools (e.g., synonyms, business context)
     # Helps LLMs understand when and why the datasets should be joined
+    # Either a free-form string, or a structured object:
+    # ai_context:
+    #   instructions: string  # Instructions for AI on how to use this entity
+    #   synonyms: []          # Alternative names and terms
+    #   examples: []          # Sample questions or use cases
     ai_context: string
 
     # Optional: Vendor-specific attributes for extensibility

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -67,7 +67,14 @@ semantic_model:
     description: string
 
     # Optional: Additional context for AI tools (e.g., custom prompts, instructions)
-    ai_context: string
+    # Can be either:
+    #   - A free-form string, or
+    #   - A structured object with optional keys:
+    #       instructions: string  # how AI should use this entity
+    #       synonyms:     []      # alternative names / terms
+    #       examples:     []      # sample questions or use cases
+    #     (additionalProperties: true, so vendors may add more keys)
+    ai_context: {}  # see AIContext in ossie-schema.json
 
     # Required: Collection of logical datasets (fact and dimension tables)
     # See Logical Dataset section below for detailed structure
@@ -128,7 +135,7 @@ datasets:
 
     # Optional: Additional context for AI tools (e.g., synonyms, common terms)
     # Helps LLMs understand the business meaning and generate better queries
-    ai_context: string
+    ai_context: {}  # see AIContext in ossie-schema.json
 
     # Optional: Row-level calculations for grouping, filtering, and in metric expressions
     # See Fields section below for detailed structure
@@ -171,15 +178,8 @@ relationships:
     #   - [order_id, line_number]    # Composite key
     to_columns: []  # Array of column names
 
-    # Optional: Additional context for AI tools
+    # Optional: Additional context for AI tools (e.g., synonyms, business context)
     # Helps LLMs understand when and why the datasets should be joined
-    # Can be either:
-    #   - A free-form string, or
-    #   - A structured object with optional keys:
-    #       instructions: string  # how AI should use this relationship
-    #       synonyms:     []      # alternative names / terms
-    #       examples:     []      # sample questions or use cases
-    #     (additionalProperties: true, so vendors may add more keys)
     ai_context: {}  # see AIContext in ossie-schema.json
 
     # Optional: Vendor-specific attributes for extensibility
@@ -235,7 +235,7 @@ fields:
 
     # Optional: Additional context for AI tools (e.g., synonyms, business terms)
     # Helps LLMs understand the field meaning and generate better queries
-    ai_context: string
+    ai_context: {}  # see AIContext in ossie-schema.json
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:
@@ -272,7 +272,7 @@ metrics:
 
     # Optional: Additional context for AI tools (e.g., synonyms, business context)
     # Helps LLMs understand the metric meaning and suggest it appropriately
-    ai_context: string
+    ai_context: {}  # see AIContext in ossie-schema.json
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -171,14 +171,16 @@ relationships:
     #   - [order_id, line_number]    # Composite key
     to_columns: []  # Array of column names
 
-    # Optional: Additional context for AI tools (e.g., synonyms, business context)
+    # Optional: Additional context for AI tools
     # Helps LLMs understand when and why the datasets should be joined
-    # Either a free-form string, or a structured object:
-    # ai_context:
-    #   instructions: string  # Instructions for AI on how to use this entity
-    #   synonyms: []          # Alternative names and terms
-    #   examples: []          # Sample questions or use cases
-    ai_context: string
+    # Can be either:
+    #   - A free-form string, or
+    #   - A structured object with optional keys:
+    #       instructions: string  # how AI should use this relationship
+    #       synonyms:     []      # alternative names / terms
+    #       examples:     []      # sample questions or use cases
+    #     (additionalProperties: true, so vendors may add more keys)
+    ai_context: {}  # see AIContext in ossie-schema.json
 
     # Optional: Vendor-specific attributes for extensibility
     custom_extensions:


### PR DESCRIPTION
## Summary

`spec.yaml` understated `ai_context` in two different ways. On `Relationship` the field was missing outright, even though the JSON schema's `$defs/Relationship` carries it and the spec.md property table lists it. On the other four nodes it was written as `ai_context: string`, while the schema defines AIContext as string-or-object with `additionalProperties: true`, spec.md documents it as `string/object` at all five nodes, and the canonical TPC-DS example uses the object form.

The notation is the one suggested in #141 and asked for during the review of #221: an open map as the value, the two accepted forms spelled out once where the field first appears, and a pointer to AIContext in the JSON schema at each site. Nothing normative changes. The JSON schema is untouched and already accepts both forms, as do the Python models.

The first commit adds the field to `Relationship`, the second aligns the remaining four nodes. `spec.yaml` still parses.

## Related Issues

Fixes #340. Also covers #141, which asked for exactly this alignment; #221 proposed it as well but has had changes requested since July without an update.
