### PR TITLE
Add THOUGHTSPOT to the Dialect enum and SKIP_SQL_VALIDATION

### DIFF
--- a/core-spec/ossie-schema.json
+++ b/core-spec/ossie-schema.json
@@ -23,7 +23,7 @@
   "$defs": {
     "Dialect": {
       "type": "string",
-      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY"],
+      "enum": ["ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL", "BIGQUERY", "THOUGHTSPOT"],
       "description": "Supported SQL and expression language dialects"
     },
     "Vendor": {

--- a/core-spec/spec.md
+++ b/core-spec/spec.md
@@ -58,6 +58,7 @@ Supported SQL and expression language dialects for metrics and field definitions
 | `DATABRICKS` | Databricks SQL |
 | `MAQL` | GoodData MAQL (Metric Analysis and Query Language) |
 | `BIGQUERY` | Google BigQuery (GoogleSQL) |
+| `THOUGHTSPOT` | ThoughtSpot formula language |
 
 ### Data types
 

--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -37,6 +37,7 @@ dialects:
   - "DATABRICKS"            # Databricks SQL
   - "MAQL"                  # GoodData MAQL (Multi-Dimensional Analytical Query Language)
   - "BIGQUERY"              # Google BigQuery GoogleSQL
+  - "THOUGHTSPOT"           # ThoughtSpot formula language (not SQL)
 
 # Supported logical data types for fields and metrics
 # TODO: Generate this list from the authoritative DataType enum in

--- a/python/src/ossie/models.py
+++ b/python/src/ossie/models.py
@@ -32,6 +32,7 @@ class OssieDialect(str, Enum):
     TABLEAU = "TABLEAU"
     DATABRICKS = "DATABRICKS"
     BIGQUERY = "BIGQUERY"
+    THOUGHTSPOT = "THOUGHTSPOT"
 
 
 class OssieDataType(str, Enum):

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -69,10 +69,11 @@ DIALECT_MAP = {
     "MDX": None,  # Not supported by sqlglot, skip validation
     "TABLEAU": None,  # Not supported by sqlglot, skip validation
     "MAQL": None,  # Not supported by sqlglot, skip validation
+    "THOUGHTSPOT": None,  # Not supported by sqlglot, skip validation
 }
 
 # Dialects that sqlglot cannot parse
-SKIP_SQL_VALIDATION = {"MDX", "TABLEAU", "MAQL"}
+SKIP_SQL_VALIDATION = {"MDX", "TABLEAU", "MAQL", "THOUGHTSPOT"}
 
 
 def validate_schema(data: dict, schema: dict) -> list[str]:


### PR DESCRIPTION
## Summary

Registers `THOUGHTSPOT` as an expression-language dialect, mirroring exactly what `MDX`, `TABLEAU` and `MAQL` already do.

ThoughtSpot's formula language is not SQL. It has its own syntax and its own column-reference form:

```
concat ( [ORDERS::Region] , ' - ' , [ORDERS::Segment] )
if ( [Revenue] > 0 ) then 'positive' else 'zero or below'
```

Two things follow. `Dialect` is a closed enum, so a `THOUGHTSPOT` entry fails schema validation outright. And `validate_sql` falls through to a default-dialect sqlglot parse for anything not in `SKIP_SQL_VALIDATION`, so such an expression would raise a parse error rather than being left alone — which is precisely why `MDX`, `TABLEAU` and `MAQL` are in that set.

### Evidence

A semantic model carrying ThoughtSpot expressions on both a field and a metric, against `validation/validate.py`:

**Before**
```
Validation FAILED with 2 error(s):
  [Schema] ... fields -> 0 -> expression -> dialects -> 0 -> dialect:
      'THOUGHTSPOT' is not one of ['ANSI_SQL', 'SNOWFLAKE', 'MDX', 'TABLEAU', 'DATABRICKS', 'MAQL', 'BIGQUERY']
  [Schema] ... metrics -> 0 -> expression -> dialects -> 0 -> dialect:
      'THOUGHTSPOT' is not one of [...]
```

**After**
```
Validation PASSED
```

Existing `python/` and `validation/` suites: 19 passed.

### Impact on existing implementations

None. No behaviour changes for any other dialect — the change is additive to a vocabulary. A consumer that does not know `THOUGHTSPOT` treats it as it would any dialect it does not implement.

### Why five files

The dialect vocabulary is stated in five places, and they have to agree:

| File | Change |
|---|---|
| `core-spec/ossie-schema.json` | the `Dialect` enum |
| `core-spec/spec.md` | the dialect table |
| `core-spec/spec.yaml` | the `dialects` list |
| `validation/validate.py` | `DIALECT_MAP` entry (`None`) + `SKIP_SQL_VALIDATION` |
| `python/src/ossie/models.py` | the `OssieDialect` enum |

The last is easy to overlook — without it the JSON schema accepts the dialect while the shared Python models package still rejects it.

The `DIALECT_MAP` entry is strictly redundant, since `SKIP_SQL_VALIDATION` short-circuits before the lookup, but `MDX`/`TABLEAU`/`MAQL` are each in both and I have followed that pattern rather than diverge from it.

### Possibly relevant beyond this dialect

In discussion #342 on shared filters, part of the argument turns on a parse-based join-path resolution strategy being unworkable for any dialect in `SKIP_SQL_VALIDATION`. That set currently has three members; this would make it four. Better known while that design is under discussion than after.

## Related Issues

Context: #285 and #269 (ThoughtSpot converter). Announced on `dev@ossie.apache.org`: [[DISCUSS] ThoughtSpot converter: scope, licensing, and where it should live](https://lists.apache.org/thread/j186q87txcrml5nygjq0zf225oz3vnb6), with a dedicated thread for this change.

Per CONTRIBUTING's specification-change process this is opened alongside the dev@ announcement, for the 7-day discussion window and a `[VOTE]`.

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [x] Spec changes have been discussed on the mailing list or in a linked issue
- [x] Breaking changes to the spec are clearly called out in the summary — there are none; the change is additive

### Validation
- [x] Validation rules in `validation/` are updated
- [ ] New validation cases are covered by tests — no existing test references any specific dialect member; happy to add one if reviewers would like

### Tests
- [x] All existing tests pass (19 passed)

### Compliance
- [x] ASF license headers are present on all new source files — no new files
- [x] No third-party dependencies are added