### PR TITLE
fix(Databricks): round-trip display_name on measures (#326)

### DIFF
--- a/converters/databricks/README.md
+++ b/converters/databricks/README.md
@@ -86,10 +86,10 @@ Each row maps in both directions; the **Notes** flag where a behavior is specifi
 | `dataset.fields[]` | `dimensions[]` | Export: fields flatten into one list and a joined column is qualified by its full join path (`customer.c_name`; `customer.region.r_name` when nested). |
 | `field.expression.dialects[]` | `expr` | Export: prefer the `DATABRICKS` dialect, else `ANSI_SQL`. |
 | `metrics[]` | `measures[]` | Export: fact columns are referenced bare (`SUM(amount)`). |
-| `field.label` | `display_name` | |
+| `field.label` | dimension `display_name` | A measure's `display_name` has no `label` on the Apache Ossie metric shape, so it rides in the stash instead (see the `custom_extensions` row). |
 | `field` / `metric` `description` | `comment` | |
 | `ai_context.synonyms` | `synonyms` | |
-| `custom_extensions[DATABRICKS]` | `filter`, `window`, `format`, `rely`, `materialization` | Import stashes Metric View only features here; export restores them -- keeping `MV -> Apache Ossie -> MV` lossless. |
+| `custom_extensions[DATABRICKS]` | `filter`, `window`, `format`, `rely`, `materialization`, measure `display_name` | Import stashes Metric View only features here; export restores them -- keeping `MV -> Apache Ossie -> MV` lossless. |
 
 ## Requirements
 

--- a/converters/databricks/src/ossie_databricks/metric_view_to_ossie.py
+++ b/converters/databricks/src/ossie_databricks/metric_view_to_ossie.py
@@ -53,6 +53,12 @@ from ._common import (
 _MODEL_STASH_KEYS = ("filter", "parameters", "materialization")
 _JOIN_STASH_KEYS = ("rely", "cardinality")
 _COLUMN_STASH_KEYS = ("format", "window")
+# Measure-only fields with no native Apache Ossie Metric representation. A dimension's
+# display_name maps to the Apache Ossie field `label`, but the metric shape has no `label`,
+# so a measure's display_name is preserved in the DATABRICKS stash instead (the same
+# mechanism as format/window). Kept separate from _COLUMN_STASH_KEYS so the dimension
+# path -- which already maps display_name to `label` -- does not also stash it.
+_MEASURE_STASH_KEYS = ("display_name",)
 
 
 def _warn(scope, msg):
@@ -362,5 +368,6 @@ def _convert_measure(measure, fact_name):
         metric["description"] = measure["comment"]
     if measure.get("synonyms"):
         metric["ai_context"] = {"synonyms": list(measure["synonyms"])}
-    write_stash(metric, {k: measure[k] for k in _COLUMN_STASH_KEYS if k in measure})
+    stash_keys = _COLUMN_STASH_KEYS + _MEASURE_STASH_KEYS
+    write_stash(metric, {k: measure[k] for k in stash_keys if k in measure})
     return metric

--- a/converters/databricks/src/ossie_databricks/metric_view_to_ossie.py
+++ b/converters/databricks/src/ossie_databricks/metric_view_to_ossie.py
@@ -53,11 +53,8 @@ from ._common import (
 _MODEL_STASH_KEYS = ("filter", "parameters", "materialization")
 _JOIN_STASH_KEYS = ("rely", "cardinality")
 _COLUMN_STASH_KEYS = ("format", "window")
-# Measure-only fields with no native Apache Ossie Metric representation. A dimension's
-# display_name maps to the Apache Ossie field `label`, but the metric shape has no `label`,
-# so a measure's display_name is preserved in the DATABRICKS stash instead (the same
-# mechanism as format/window). Kept separate from _COLUMN_STASH_KEYS so the dimension
-# path -- which already maps display_name to `label` -- does not also stash it.
+# A dimension's display_name maps to the field `label`, but a metric has no `label`, so a
+# measure's display_name is stashed instead.
 _MEASURE_STASH_KEYS = ("display_name",)
 
 

--- a/converters/databricks/src/ossie_databricks/ossie_to_metric_view.py
+++ b/converters/databricks/src/ossie_databricks/ossie_to_metric_view.py
@@ -571,9 +571,6 @@ def _convert_metric(metric, fact, seen_names):
         measure["format"] = stash["format"]
     if "window" in stash:
         measure["window"] = stash["window"]
-    # The Apache Ossie metric shape has no `label`, so a measure's display_name round-trips
-    # through the DATABRICKS stash (see _MEASURE_STASH_KEYS on the import side) rather than a
-    # native field.
     if "display_name" in stash:
         measure["display_name"] = stash["display_name"]
     return measure

--- a/converters/databricks/src/ossie_databricks/ossie_to_metric_view.py
+++ b/converters/databricks/src/ossie_databricks/ossie_to_metric_view.py
@@ -571,6 +571,11 @@ def _convert_metric(metric, fact, seen_names):
         measure["format"] = stash["format"]
     if "window" in stash:
         measure["window"] = stash["window"]
+    # The Apache Ossie metric shape has no `label`, so a measure's display_name round-trips
+    # through the DATABRICKS stash (see _MEASURE_STASH_KEYS on the import side) rather than a
+    # native field.
+    if "display_name" in stash:
+        measure["display_name"] = stash["display_name"]
     return measure
 
 

--- a/converters/databricks/tests/_roundtrip_helpers.py
+++ b/converters/databricks/tests/_roundtrip_helpers.py
@@ -180,6 +180,8 @@ def build_metric_view(rnd):
         if rnd.chance(0.4):
             m["comment"] = rnd.text()
         if rnd.chance(0.3):
+            m["display_name"] = rnd.text()
+        if rnd.chance(0.3):
             m["synonyms"] = [rnd.text() for _ in range(rnd.count(1, 3))]
         if rnd.chance(0.3):
             m["window"] = [{"order": rnd.colname(), "range": "trailing 7 day"}]

--- a/converters/databricks/tests/test_roundtrip.py
+++ b/converters/databricks/tests/test_roundtrip.py
@@ -79,6 +79,24 @@ def test_one_to_many_round_trips_mv_ossie_mv():
     assert parse(mv_out) == parse(mv_in)
 
 
+def test_measure_display_name_survives_round_trip_via_stash():
+    """A measure's display_name survives MV -> Apache Ossie -> MV. A dimension's
+    display_name maps to the Apache Ossie field `label`, but the metric shape has no
+    `label`, so a measure's display_name rides in the DATABRICKS stash (like format/window)
+    and is restored on the way back (apache/ossie#326)."""
+    mv_in = (
+        "version: '1.1'\nsource: c.s.fact\n"
+        "dimensions:\n- {name: region, expr: region}\n"
+        "measures:\n- {name: total_revenue, expr: SUM(amount), display_name: Total Revenue}\n"
+    )
+    ossie = importer.convert_metric_view_to_ossie(mv_in)
+    # The only display_name in the input is on the measure; it must ride in the metric's
+    # stash, since there is no native Apache Ossie field for it.
+    assert "display_name" in ossie
+    mv_out = exporter.convert_ossie_to_metric_view(ossie)
+    assert parse(mv_out) == parse(mv_in)
+
+
 # Property-based round-trip coverage. The Hypothesis driver lives in
 # test_roundtrip_properties.py; these run the same generators/assertions under a plain
 # seeded RNG so the property coverage also holds where Hypothesis is not installed.


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

The Databricks converter dropped a measure's `display_name` during the `MV -> Ossie -> MV` round trip. A dimension's `display_name` maps to the Apache Ossie field `label`, but the Apache Ossie metric shape has no `label`, so a measure's `display_name` had nowhere to go and was silently lost.

This preserves it in the `custom_extensions[DATABRICKS]` stash (the same mechanism already used for `format` and `window`).

## Related Issues

Fixes [#326](https://github.com/apache/ossie/issues/326) for the python converter.  https://github.com/apache/ossie/pull/333 will be augmented to include this fix for the Java converter.

## Checklist

### Specification
N/A - no spec changes
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [x] Spec changes have been discussed on the mailing list or in a linked issue
- [x] Breaking changes to the spec are clearly called out in the summary

### Ontology
N/A - no ontology changes
- [X] Ontology changes in `ontology/` are consistent with spec changes
- [x] New or modified terms are defined and documented

### Converters

- [x] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [x] New converters include tests under the converter's test directory

### Validation
N/A - no new validation rules
- [x] Validation rules in `validation/` are updated if the spec changed
- [x] New validation cases are covered by tests

### Documentation
N/A no docs
- [x] `docs/` is updated to reflect any user-facing changes
- [x] New features or behaviors are documented with examples where appropriate
- [x] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
N/A - no new examples
- [x] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval

##  AI disclosure
Per the ASF Generative Tooling Guidance, this contribution was prepared with AI assistance. All specification decisions and design choices are mine. I have reviewed and verified every change.