### PR TITLE
fix(examples): use d_moy for the TPC-DS date_dim month field

### DIFF
--- a/converters/omni/tests/fixtures/tpcds_omni/views/date_dim.view.yaml
+++ b/converters/omni/tests/fixtures/tpcds_omni/views/date_dim.view.yaml
@@ -57,8 +57,8 @@ dimensions:
     - month
     - quarter
     - year
-  d_month_name:
-    description: Month name
+  d_moy:
+    description: Month of year (1-12)
     synonyms:
     - month
     timeframes:

--- a/converters/orionbelt/tests/fixtures/obml_as_ossie.yaml
+++ b/converters/orionbelt/tests/fixtures/obml_as_ossie.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '0.1.1'
+version: '0.2.0.dev0'
 semantic_model:
 - name: sales_analytics
   description: Sales, Returns, Shipments and Purchases Analytics

--- a/converters/orionbelt/tests/fixtures/tpcds_as_obml.yaml
+++ b/converters/orionbelt/tests/fixtures/tpcds_as_obml.yaml
@@ -137,10 +137,10 @@ dataObjects:
         customExtensions:
         - vendor: Ossie
           data: '{"synonyms": ["quarter", "fiscal quarter"]}'
-      d_month_name:
-        code: d_month_name
+      d_moy:
+        code: d_moy
         abstractType: date
-        comment: Month name
+        comment: Month of year (1-12)
         customExtensions:
         - vendor: Ossie
           data: '{"synonyms": ["month"]}'
@@ -299,9 +299,9 @@ dimensions:
     dataObject: date_dim
     column: d_quarter_name
     resultType: date
-  d_month_name:
+  d_moy:
     dataObject: date_dim
-    column: d_month_name
+    column: d_moy
     resultType: date
   c_customer_id:
     dataObject: customer

--- a/converters/orionbelt/tests/fixtures/tpcds_ossie.yaml
+++ b/converters/orionbelt/tests/fixtures/tpcds_ossie.yaml
@@ -21,7 +21,7 @@
 # This example demonstrates the Ossie Core Metadata Spec using the TPC-DS benchmark schema
 # TPC-DS is a decision support benchmark with a realistic retail business model
 
-version: "0.1.1"
+version: "0.2.0.dev0"
 
 semantic_model:
   - name: tpcds_retail_model

--- a/converters/orionbelt/tests/fixtures/tpcds_ossie.yaml
+++ b/converters/orionbelt/tests/fixtures/tpcds_ossie.yaml
@@ -202,12 +202,12 @@ semantic_model:
                 - "quarter"
                 - "fiscal quarter"
 
-          - name: d_month_name
+          - name: d_moy
             expression:
               dialects:
                 - dialect: ANSI_SQL
-                  expression: d_month_name
-            description: Month name
+                  expression: d_moy
+            description: Month of year (1-12)
             dimension:
               is_time: true
             ai_context:

--- a/converters/orionbelt/tests/fixtures/tpcds_semantic_model.yaml
+++ b/converters/orionbelt/tests/fixtures/tpcds_semantic_model.yaml
@@ -202,12 +202,12 @@ semantic_model:
                 - "quarter"
                 - "fiscal quarter"
 
-          - name: d_month_name
+          - name: d_moy
             expression:
               dialects:
                 - dialect: ANSI_SQL
-                  expression: d_month_name
-            description: Month name
+                  expression: d_moy
+            description: Month of year (1-12)
             dimension:
               is_time: true
             ai_context:

--- a/converters/snowflake/tests/example_converted_tpcds_semantic_model.yaml
+++ b/converters/snowflake/tests/example_converted_tpcds_semantic_model.yaml
@@ -136,9 +136,9 @@ tables:
     synonyms:
     - quarter
     - fiscal quarter
-  - name: d_month_name
-    expr: d_month_name
-    description: Month name
+  - name: d_moy
+    expr: d_moy
+    description: Month of year (1-12)
     synonyms:
     - month
 - name: customer

--- a/examples/tpcds_semantic_model.yaml
+++ b/examples/tpcds_semantic_model.yaml
@@ -215,12 +215,12 @@ semantic_model:
 
           # Declares temporal role via is_time without a datatype annotation.
           # Both datatype and is_time are independently optional.
-          - name: d_month_name
+          - name: d_moy
             expression:
               dialects:
                 - dialect: ANSI_SQL
-                  expression: d_month_name
-            description: Month name
+                  expression: d_moy
+            description: Month of year (1-12)
             dimension:
               is_time: true
             ai_context:


### PR DESCRIPTION

## Summary

`examples/tpcds_semantic_model.yaml` declares a `d_month_name` field on `date_dim` with `expression: d_month_name`. TPC-DS has no such column. The month column is `d_moy` (1-12); `d_day_name` and `d_quarter_name` do exist, which is probably where the name came from. A conversion round-trip never touches the physical table, so the field converts cleanly in every suite and only fails when something executes the model against real TPC-DS data, as reported in #358.

This renames the field and its expression to `d_moy` and updates the description. Several converter fixtures are copies or conversions of the canonical example, so the same rename is applied to them, both to keep them consistent and because the omni tests export the canonical example and compare it against the `tpcds_omni` fixture:

- `converters/orionbelt/tests/fixtures/`: `tpcds_ossie.yaml`, `tpcds_semantic_model.yaml`, `tpcds_as_obml.yaml`
- `converters/omni/tests/fixtures/tpcds_omni/views/date_dim.view.yaml`
- `converters/snowflake/tests/example_converted_tpcds_semantic_model.yaml`

The field keeps `is_time: true` with no `datatype`, since the comment above it uses this field to show that the two annotations are independent.

Separately, two orionbelt fixtures (`tpcds_ossie.yaml`, `obml_as_ossie.yaml`) still declared `version: 0.1.1`, which the schema's `version` const rejects. They now declare `0.2.0.dev0`. No test loads either file, so this only changes standalone validation. Whether `version` should remain a `const` is a separate question raised in #357; this PR only brings the fixtures in line with the schema as it stands.

Checked:

- DuckDB `tpcds` extension at `sf=0.01`: `date_dim` has 28 columns, none named `d_month_name`; `d_moy` resolves.
- `validation/validate.py` passes on the canonical example and on all three orionbelt Ossie-format fixtures. Before this change `tpcds_ossie.yaml` failed with `'0.2.0.dev0' was expected`.
- Converter tests: orionbelt 154 passed, omni 83 passed / 3 skipped, snowflake 107 passed, honeydew TPC-DS round-trip passed.
- `grep -rn d_month_name` over the repo returns nothing.

## Related Issues

Fixes #357. Fixes #358.

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [ ] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [x] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [ ] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval