### PR TITLE
core-spec: move semantic_model out of the Enumerations section in spec.yaml

### DIFF
--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -59,6 +59,11 @@ datatypes:
 vendor_name: string
 
 
+---
+# Document root
+# Keys allowed on the root object of an Ossie document, alongside the `version`
+# declared at the top of this file.
+
 # Top-level semantic model definition
 semantic_model:
   # Required: Unique identifier for the semantic model


### PR DESCRIPTION
## Summary

`core-spec/spec.yaml` is a multi-document YAML file whose `---` separators group the
specification into sections. `semantic_model` is a document-root key, but it sits *after* the
`# Enumerations` separator, so it parses as a member of that section alongside the enum
definitions.

On `main` today:

```python
>>> [list(d) for d in yaml.safe_load_all(open("core-spec/spec.yaml"))]
[['version'],
 ['dialects', 'datatypes', 'vendor_name', 'semantic_model'],   # <-- root key in # Enumerations
 ['datasets'],
 ['relationships'],
 ['fields'],
 ['metrics']]
```

This PR gives the document-root keys their own section, matching how every other section in
the file is delimited:

```python
[['version'],
 ['dialects', 'datatypes', 'vendor_name'],
 ['semantic_model'],
 ['datasets'],
 ['relationships'],
 ['fields'],
 ['metrics']]
```

## Scope

Five added lines, all of them a `---` separator and comments. **No key, value or enum member
is added, removed, renamed or reordered**, so the parsed content of the file is unchanged
apart from which section `semantic_model` belongs to.

Nothing in the repository parses `core-spec/spec.yaml` — it is documentation. (The two
`spec.yaml` references under `converters/ontology/tests/` are unrelated `tmp_path` fixtures.)
So this carries no runtime risk; it makes the file say what it already meant.

Noticed while preparing #323, and split out of it so that PR stays about one thing.

## Related Issues

None.

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue — not applicable, this is a comment-only sectioning fix with no semantic change
- [x] Breaking changes to the spec are clearly called out in the summary — there are none

### Ontology
- [x] Ontology changes in `ontology/` are consistent with spec changes — `ontology/` is untouched
- [x] New or modified terms are defined and documented — no terms added or modified

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes — not applicable, nothing parses this file
- [ ] New converters include tests under the converter's test directory — not applicable

### Validation
- [x] Validation rules in `validation/` are updated if the spec changed — no change needed; `validate.py` reads `ossie-schema.json`, not `spec.yaml`
- [x] New validation cases are covered by tests — not applicable; existing suites re-run green (`test_validate.py` 34 passed, `validation/tests/` 10 passed)

### Documentation
- [x] `docs/` is updated to reflect any user-facing changes — no user-facing change
- [x] New features or behaviors are documented with examples where appropriate — no new behavior
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed — not applicable

### Examples
- [x] `examples/` are added or updated for any new spec constructs — no new constructs

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests — no new functionality

### Compliance
- [x] ASF license headers are present on all new source files — no new files added
- [x] No third-party dependencies are added without PMC/IPMC approval — none added
