### PR TITLE
ci(dependabot): ignore major updates for json-schema-validator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,7 @@ updates:
       maven-dependencies:
         patterns:
           - "*"
+    ignore:
+      # 2.x/3.x introduced breaking package/API changes; only allow minor/patch updates
+      - dependency-name: "com.networknt:json-schema-validator"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- `com.networknt:json-schema-validator` 3.x introduced breaking package/API changes vs 1.x (classes like `JsonSchema`, `JsonSchemaFactory`, `SpecVersion`, `ValidationMessage` moved), which broke the salesforce converter build when Dependabot bumped it in #366
- Add an `ignore` rule to `.github/dependabot.yml` so Dependabot only proposes minor/patch updates for this dependency going forward