### PR TITLE
Correct ontology schema's $id field

### DIFF
--- a/ontology/ontology.json
+++ b/ontology/ontology.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/apache/ossie/core-spec/ossie-schema.json",
+  "$id": "https://github.com/apache/ossie/core-spec/ontology.json",
   "title": "Apache Ossie Ontology Metadata Specification",
   "description": "JSON Schema for validating Apache Ossie ontology definitions",
   "type": "object",

--- a/ontology/ontology.json
+++ b/ontology/ontology.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/apache/ossie/core-spec/ontology.json",
+  "$id": "https://github.com/apache/ossie/ontology/ontology.json",
   "title": "Apache Ossie Ontology Metadata Specification",
   "description": "JSON Schema for validating Apache Ossie ontology definitions",
   "type": "object",


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

## Summary

Change the `$id` of the ontology schema from `https://github.com/apache/ossie/core-spec/ossie-schema.json` to `https://github.com/apache/ossie/core-spec/ontology.json`.

ossie-schema.json is already taken by the main schema, which is also referenced in the ontology schema (`properties.ai_context.$ref`). This reference resolves incorrectly to the ontology schema (this JSON file), breaking validators. The `semantic_model` ref is broken in the same way.

## Related Issues

N/A

## Checklist

### Ontology
- [x] Ontology changes in `ontology/` are consistent with spec changes
- [x] New or modified terms are defined and documented

### Tests
- [x] All existing tests pass (`pytest` / CI green)

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval