### PR TITLE
[DBT] Skip FOREIGN<->FOREIGN entity pairs when building relationships

### DIFF
--- a/converters/dbt/src/ossie_dbt/msi_to_ossie.py
+++ b/converters/dbt/src/ossie_dbt/msi_to_ossie.py
@@ -391,18 +391,27 @@ class MSIToOssieConverter:
             return _RelationshipDirection(from_dataset=ds_a, to_dataset=ds_b, from_col=col_a, to_col=col_b)
         return _RelationshipDirection(from_dataset=ds_b, to_dataset=ds_a, from_col=col_b, to_col=col_a)
 
+    _ONE_SIDE_ENTITY_TYPES = {EntityType.PRIMARY, EntityType.UNIQUE}
+
     @staticmethod
     def _build_relationships(
         entity_index: Dict[str, List[_EntityEntry]],
     ) -> List[OssieRelationship]:
         """Resolve implicit MSI entity links into explicit Ossie relationships.
 
-        Every pair of datasets sharing an entity name is a valid join path.
+        Every pair of datasets sharing an entity name is a candidate join path, except when
+        both sides declare that entity as FOREIGN: `to_columns` must be a primary/unique key
+        of the `to` dataset (per the Ossie spec), which no FOREIGN-side column is.
         """
         relationships: List[OssieRelationship] = []
         for entity_name, entries in entity_index.items():
             for entry_a, entry_b in combinations(entries, 2):
                 if entry_a.dataset == entry_b.dataset:
+                    continue
+                if (
+                    entry_a.entity_type not in MSIToOssieConverter._ONE_SIDE_ENTITY_TYPES
+                    and entry_b.entity_type not in MSIToOssieConverter._ONE_SIDE_ENTITY_TYPES
+                ):
                     continue
                 direction = MSIToOssieConverter._relationship_direction(
                     entry_a.dataset,

--- a/converters/dbt/tests/test_msi_to_ossie.py
+++ b/converters/dbt/tests/test_msi_to_ossie.py
@@ -491,6 +491,48 @@ class TestRelationshipConversion:
         assert rels[0].from_dataset == "alpha"
         assert rels[0].to == "beta"
 
+    def test_foreign_foreign_pair_produces_no_relationship(self) -> None:
+        """Neither side of a FOREIGN<->FOREIGN pair is a key of the other; to_columns would be invalid (ossie#301)."""
+        customers = semantic_model_with_guaranteed_meta(
+            name="customers",
+            entities=[_entity("customer", entity_type=EntityType.PRIMARY, expr="customer_id")],
+        )
+        orders = semantic_model_with_guaranteed_meta(
+            name="orders",
+            entities=[
+                _entity("order", entity_type=EntityType.PRIMARY, expr="order_id"),
+                _entity("customer", entity_type=EntityType.FOREIGN, expr="customer_id"),
+            ],
+        )
+        reviews = semantic_model_with_guaranteed_meta(
+            name="reviews",
+            entities=[
+                _entity("review", entity_type=EntityType.PRIMARY, expr="review_id"),
+                _entity("customer", entity_type=EntityType.FOREIGN, expr="customer_id"),
+            ],
+        )
+        result = MSIToOssieConverter().convert(_manifest(semantic_models=[customers, orders, reviews])).output
+
+        rels = result.semantic_model[0].relationships
+        assert rels is not None
+        pairs = {(r.from_dataset, r.to) for r in rels}
+        # orders and reviews each join to customers; orders-reviews (both FOREIGN on `customer`) is excluded.
+        assert pairs == {("orders", "customers"), ("reviews", "customers")}
+        assert len(rels) == 2
+
+    def test_foreign_foreign_pair_excluded_even_when_only_pair(self) -> None:
+        orders = semantic_model_with_guaranteed_meta(
+            name="orders",
+            entities=[_entity("customer", entity_type=EntityType.FOREIGN, expr="customer_id")],
+        )
+        reviews = semantic_model_with_guaranteed_meta(
+            name="reviews",
+            entities=[_entity("customer", entity_type=EntityType.FOREIGN, expr="customer_id")],
+        )
+        result = MSIToOssieConverter().convert(_manifest(semantic_models=[orders, reviews])).output
+
+        assert result.semantic_model[0].relationships is None
+
 
 class TestMetricConversion:
     # --- SIMPLE ---


### PR DESCRIPTION
## Summary

`MSIToOssieConverter._build_relationships` pairs *every* combination of datasets sharing an entity name, including pairs where **both** sides declare that entity as `FOREIGN`. The resulting relationship's `to_columns` is not a primary/unique key of the `to` dataset — which contradicts the spec's own definition of that field — and Snowflake's `SYSTEM$CREATE_SEMANTIC_VIEW_FROM_YAML` rejects the whole semantic view over it: `The referenced key in the relationship '... REFERENCES ...' must be the primary or unique key of the referenced entity.` One bad relationship fails an otherwise-valid document.

This hits any star schema where more than one fact table shares a conformed dimension entity: for N fact models sharing one entity, `combinations` yields N(N+1)/2 relationships, of which only N are valid.

**Fix:** skip the pair when neither side is `PRIMARY`/`UNIQUE`. `PRIMARY<->PRIMARY` (and `UNIQUE<->UNIQUE`) pairs are unaffected — still a legitimate 1:1 join — and `test_same_type_entities_produce_relationship` continues to pass unmodified.

Verified beyond the new unit tests too: ran a repro (one dimension + two facts sharing a conformed `customer` entity) against an unpatched worktree of `main` and against this branch. Unpatched emits the invalid `orders -> reviews on customer_id` relationship on top of the two valid ones; this branch emits only the two valid ones.

## Related Issues

Fixes #301

## Checklist

### Specification
- [ ] N/A — no spec change

### Ontology
- [ ] N/A

### Converters
- [x] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [x] New tests added under the converter's test directory

### Validation
- [ ] N/A

### Documentation
- [ ] N/A

### Examples
- [ ] N/A

### Tests
- [x] All existing tests pass — ran full `converters/dbt` suite locally, 101 passed
- [x] New functionality is covered by tests — a FOREIGN<->FOREIGN repro (3 datasets, only 2 of 3 pairs valid) and a minimal 2-dataset case with no valid pair at all

### Compliance
- [x] ASF license headers present — no new files, only edits to existing licensed files
- [x] No third-party dependencies added
