### PR TITLE
[core-spec]: add FILTER (WHERE ...) aggregate modifier

### DIFF
--- a/core-spec/expression_language.md
+++ b/core-spec/expression_language.md
@@ -217,7 +217,7 @@ APPROX_PERCENTILE(response_time, 0.95)
 ### Conditional Aggregations (REQUIRED)
 
 SUM / COUNT aggregation functions support `DISTINCT.`   
-All aggregations should support filtered aggregation:
+All aggregations must support filtered aggregation, expressed either with a `CASE` argument or with a postfix `FILTER (WHERE ...)` modifier:
 
 ```sql
 -- DISTINCT modifier
@@ -227,7 +227,25 @@ COUNT(DISTINCT customer_id)
 -- Filtered aggregation via CASE
 SUM(CASE WHEN status = 'completed' THEN amount ELSE 0 END)
 COUNT(CASE WHEN status = 'completed' THEN 1 END)
+
+-- Filtered aggregation via FILTER (WHERE ...)
+SUM(amount) FILTER (WHERE status = 'completed')
+COUNT(*) FILTER (WHERE status = 'completed')
 ```
+
+#### `FILTER (WHERE ...)` (REQUIRED)
+
+Every aggregate function must support a postfix `FILTER (WHERE <predicate>)` modifier:
+
+```
+<aggregate_function>(<args>) FILTER (WHERE <predicate>)
+```
+
+The clause has the semantics of the SQL:2003 `<filter clause>` (optional feature T612): the aggregate considers only the rows for which `<predicate>` is `TRUE`.
+
+`FILTER (WHERE ...)` is a modifier on an aggregate expression. It is not the standalone `WHERE` clause listed under [Not Supported in Expressions](#not-supported-in-expressions). The `<predicate>` must reference only fields of the same dataset as the aggregate's arguments.
+
+Engines without native `FILTER (WHERE ...)` support MAY lower it to the equivalent `CASE` form.
 
 ### Decomposability Reference
 

--- a/core-spec/expression_language.md
+++ b/core-spec/expression_language.md
@@ -241,11 +241,19 @@ Every aggregate function must support a postfix `FILTER (WHERE <predicate>)` mod
 <aggregate_function>(<args>) FILTER (WHERE <predicate>)
 ```
 
-The clause has the semantics of the SQL:2003 `<filter clause>` (optional feature T612): the aggregate considers only the rows for which `<predicate>` is `TRUE`.
+The clause has the semantics of the SQL:2003 `<filter clause>` (optional feature T612): the aggregate considers only the rows for which `<predicate>` succeeds. `FILTER` is applied to the aggregate's input, not as a query `WHERE`, so it never removes output groups.
 
 `FILTER (WHERE ...)` is a modifier on an aggregate expression. It is not the standalone `WHERE` clause listed under [Not Supported in Expressions](#not-supported-in-expressions). The `<predicate>` must reference only fields of the same dataset as the aggregate's arguments.
 
-Engines without native `FILTER (WHERE ...)` support MAY lower it to the equivalent `CASE` form.
+Engines without native `FILTER (WHERE ...)` support MAY lower it to the equivalent `CASE` form:
+
+```sql
+-- value aggregate: filter the argument
+SUM(amount) FILTER (WHERE status = 'completed')  --> SUM(CASE WHEN status = 'completed' THEN amount END)
+
+-- COUNT(*): filter a constant
+COUNT(*) FILTER (WHERE status = 'completed')      --> COUNT(CASE WHEN status = 'completed' THEN 1 END)
+```
 
 ### Decomposability Reference
 


### PR DESCRIPTION
## Summary

Adds the SQL-standard `FILTER (WHERE <predicate>)` modifier to aggregate expressions in `Ossie_SQL_2026`, extending the filtered-aggregation capability already marked REQUIRED by the expression language. A metric MAY attach a per-aggregate predicate, for example `SUM(store_sales.ss_ext_sales_price) FILTER (WHERE store_sales.ss_ext_sales_price > 0)`.

The change is confined to `core-spec/expression_language.md` — specifically its **Conditional Aggregations (REQUIRED)** section. It adds no new schema node and no new field to `Metric`, `Field`, or `Dataset`. Filtered aggregation was already listed as REQUIRED in the expression language ("All aggregations should support filtered aggregation"), but the only spelled-out form was the `CASE WHEN` rewrite.

The change is additive and backward compatible. Every existing model remains valid, and the `CASE WHEN` form remains supported.

This PR was motivated by the "declare a filter on a metric, then layer filters on top" pain point from discussion [#342](https://github.com/apache/ossie/discussions/342#discussioncomment-18280099). Query-time layering itself is enabled via `MEASURE()` and is defined here for single-aggregate metrics; see Composition.

## Motivation

Many metrics include a filter as a core part of their definitions: "valid sales only", "domestic customers", "completed orders". Ossie metrics expose a single `expression`, so today filter logic has to be folded into the aggregate with `CASE WHEN`:

```yaml
metrics:
  - name: valid_sales
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: "SUM(CASE WHEN store_sales.ss_ext_sales_price > 0 THEN store_sales.ss_ext_sales_price ELSE 0 END)"
  - name: valid_profit
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: "SUM(CASE WHEN store_sales.ss_ext_sales_price > 0 THEN store_sales.ss_net_profit ELSE 0 END)"
```

Three problems follow from this:

1. **The predicate is buried inside the aggregate.** A reader, a validator, or a consumer that wants to know "what does this metric filter on" has to parse the `CASE` body. The filter has no explicit syntactic role.
2. **A consumer cannot layer an additional predicate onto an existing metric expression.** A consumer that wants "valid sales, but only for the Toys category" has no way to add a predicate to an existing metric. It must author a new `CASE` expression that repeats both predicates.
3. **The `CASE ... ELSE 0` idiom is subtly wrong for some aggregates.** It works for `SUM`, but `AVG`, `COUNT`, `MIN`, and `MAX` need `ELSE NULL` (and careful reasoning about what a substituted zero does to the result), which is a common source of incorrect metrics.

`FILTER (WHERE ...)` addresses these as a composable building block. On its own it fixes problems 1 and 3: the predicate has an explicit syntactic role rather than being encoded indirectly in a `CASE` expression, and its empty-input behavior is the aggregate's own well-defined behavior rather than a hand-chosen sentinel. Problem 2 — layering a context filter onto an existing metric — is solved not by `FILTER` alone but by `MEASURE(m) FILTER (WHERE ...)` where the Relational Query Interface ([#354](https://github.com/apache/ossie/pull/354)) is available; this iteration defines that layering only for single-aggregate metrics (see Composition).

## Prior art

`FILTER (WHERE ...)` is defined in SQL:2003 as the `<filter clause>` on a set function — [optional feature T612](https://modern-sql.com/feature/filter) — the same standard the Ossie expression language is based on. Engines split into those that support it natively and those that require a `CASE` rewrite:

| Native `FILTER (WHERE ...)` | Requires `CASE` rewrite |
| :--- | :--- |
| PostgreSQL, DuckDB, Apache Spark | Snowflake, BigQuery |

Engines in the second group have a mechanical, well-known `CASE`-rewrite, so a converter can always lower the clause to a supported form. This is the same portability posture the expression language already takes for constructs such as `APPROX_COUNT_DISTINCT`.

**Why an expression-language extension rather than a first-class `filters` node.** Discussion #342 opened with a proposal for a top-level `filters` object. This PR intentionally addresses aggregate-local filtering through the existing expression language: a predicate on an aggregate is already within the expression language's remit and needs no new node or resolution rule. Named / shared filters, cross-dataset filters, and parameterized filters require additional modeling and resolution semantics and remain out of scope.

## Proposed change

Extend `core-spec/expression_language.md` to define the aggregate `FILTER` clause. The clause is a postfix modifier on an aggregate expression:

```
<aggregate_expression>(<args>) FILTER (WHERE <predicate>)
```

`FILTER` MAY modify an aggregate expression. This includes ordinary aggregate function calls (`SUM`, `COUNT`, ...) and, where the Relational Query Interface ([#354](https://github.com/apache/ossie/pull/354)) is supported, `MEASURE(...)`.

The clause is added under the existing **Conditional Aggregations (REQUIRED)** section, alongside the `DISTINCT` modifier and the `CASE`-based form the section already describes, so that filtered aggregation has one explicit, portable spelling. The default dialect (`Ossie_SQL_2026`) supports it; dialect-specific expressions MAY continue to use their engine's native form.

Because the language's **Not Supported** table lists a bare `WHERE` clause as unsupported ("Use filter property instead"), the spec text will state explicitly that `FILTER (WHERE ...)` is a postfix aggregate modifier and is **not** the unsupported standalone `WHERE` clause, to avoid a reading conflict.

## Aggregate FILTER semantics

The `FILTER (WHERE <predicate>)` clause has the semantics of the SQL `<filter clause>` (SQL:2003 [optional feature T612](https://modern-sql.com/feature/filter)). FILTER is applied to the aggregate's input, not as a query WHERE, so it never removes output groups.

The one behavior worth calling out against the `CASE` rewrite: when no row matches, the aggregate sees a genuinely empty input and returns its correct empty-input value automatically, whereas `CASE ... ELSE <sentinel>` forces the author to hand-pick that value.

## Composition with metrics and MEASURE()

The following rules are normative and specific to Ossie. They apply **only where the Relational Query Interface ([#354](https://github.com/apache/ossie/pull/354)) is available**, since they concern layering a `FILTER` clause onto an existing metric via `MEASURE()`. Ossie has not yet defined general measure composition, so this iteration defines contextual filtering only for the single-aggregate case; the composed / multi-aggregate case is left to a future measure-composition proposal.

1. **Intrinsic vs contextual filters.** A `FILTER` clause written into a metric definition is its **intrinsic** filter. A `FILTER` clause layered onto that metric at query time via `MEASURE()` is a **contextual** filter. Both are ordinary `FILTER (WHERE ...)` clauses; the terms name where the clause was written, not two different constructs.
2. **Single-aggregate composition by `AND`.** This iteration defines contextual filtering **only** for a metric whose definition is a single aggregate expression that MAY carry an intrinsic `FILTER`. For such a metric `m` — say `m = SUM(x) FILTER (WHERE p)` — a reference `MEASURE(m) FILTER (WHERE q)` MUST evaluate exactly as `SUM(x) FILTER (WHERE p AND q)`. When `m` has no intrinsic filter, the effective predicate is just `q`. A contextual filter MUST NOT weaken or replace an intrinsic filter. Because composition is by `AND`, a contextual predicate that contradicts the intrinsic one simply produces empty filtered input, which returns the aggregate's ordinary empty-input value — no special-casing is required.
3. **`MEASURE()` interaction.** `MEASURE(m)` behaves as an aggregate, so `MEASURE(m) FILTER (WHERE q)` MUST apply `q` per rule 2.

## Scope and resolution constraints

The following is an Ossie modeling restriction for this iteration, not part of SQL `FILTER` semantics:

- **Single dataset only.** A `FILTER (WHERE ...)` predicate MUST reference only fields of the same dataset as the base aggregate. A predicate that references another dataset is out of scope for this iteration and MUST be rejected. This avoids coupling filtered aggregation to relationship-path resolution, which is being specified separately.

## Examples

**Intrinsic filter in a metric definition** (uses `FILTER` alone; no `MEASURE()` required):

```yaml
metrics:
  - name: northern_sales
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: "SUM(store_sales.ss_ext_sales_price) FILTER (WHERE store_sales.ss_store_region = 'North')"
```

**Reusing a boolean field on the dataset as the predicate** (reference an existing field instead of re-authoring the condition). Here `store_sales.is_valid_sale` is a boolean field on the `store_sales` dataset — the only kind of reuse this iteration supports. The same pattern should extend to a boolean dimension in the future, once Ossie defines how to build measures from dimensions:

```yaml
metrics:
  - name: valid_sales
    expression:
      dialects:
        - dialect: ANSI_SQL
          expression: "SUM(store_sales.ss_ext_sales_price) FILTER (WHERE store_sales.is_valid_sale)"
```

**Contextual filter layered at query time** (requires the Relational Query Interface, #354). This is well-defined because `northern_sales` is a single aggregate; the effective predicate is `ss_store_region = 'North' AND ss_category = 'Toys'`:

```sql
SELECT MEASURE(northern_sales) FILTER (WHERE ss_category = 'Toys')
FROM store_sales_metrics
```

## Open questions

- **REQUIRED vs RECOMMENDED (discussion point).** This PR proposes that native `FILTER (WHERE ...)` support be **REQUIRED** of the default dialect. Whether it should instead be only RECOMMENDED — with the `CASE`-rewrite as the portable fallback for engines and converters that do not implement it natively — is open for discussion. Filtered aggregation is already REQUIRED; this question is specifically about whether the `FILTER` spelling itself must be supported.

## Related Issues

Discussion: [#342](https://github.com/apache/ossie/discussions/342), [#5](https://github.com/apache/ossie/discussions/5). Related PRs: [#354](https://github.com/apache/ossie/pull/354) (Relational Query Interface / `MEASURE()`), [#246](https://github.com/apache/ossie/pull/246) (Foundational Semantics).

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure — `core-spec/expression_language.md`
- [ ] Spec changes have been discussed on the mailing list or in a linked issue — discussed in #342; a `[DISCUSS]` thread on `dev@ossie.apache.org` is still to come
- [x] Breaking changes to the spec are clearly called out in the summary — N/A, purely additive; no schema change

### Ontology
- [x] Ontology changes in `ontology/` are consistent with spec changes — N/A, no ontology change
- [x] New or modified terms are defined and documented — N/A, no ontology changes

### Converters
- [ ] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [x] New converters include tests under the converter's test directory — N/A, no new converters

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [x] `docs/` is updated to reflect any user-facing changes — the change is itself a spec document
- [x] New features or behaviors are documented with examples where appropriate — worked examples included
- [x] `CONTRIBUTING.md` is updated if the contribution process changed — N/A

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support — add a filtered-metric example to the TPC-DS model

### Tests
- [ ] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files — ASF header added at the top of `ossie/filter-where-spec.md`
- [x] No third-party dependencies are added without PMC/IPMC approval

## AI disclosure

Per the ASF Generative Tooling Guidance, this contribution was prepared with AI assistance. All specification decisions and design choices are mine. I have reviewed and verified every change.
