### PR TITLE
docs(core-spec): add missing SIGMA dialect to spec.yaml enum

### DIFF
--- a/core-spec/spec.yaml
+++ b/core-spec/spec.yaml
@@ -37,6 +37,7 @@ dialects:
   - "DATABRICKS"            # Databricks SQL
   - "MAQL"                  # GoodData MAQL (Multi-Dimensional Analytical Query Language)
   - "BIGQUERY"              # Google BigQuery GoogleSQL
+  - "SIGMA"                 # Sigma Computing spreadsheet-style formula language
   - "THOUGHTSPOT"           # ThoughtSpot formula language (not SQL)
 
 # Supported logical data types for fields and metrics


### PR DESCRIPTION
## Summary

The `dialects` enum in `core-spec/spec.yaml` omitted `SIGMA`, while both the
authoritative JSON schema (`core-spec/ossie-schema.json`) and the
human-readable specification (`core-spec/spec.md`) already list it. This adds
`SIGMA` between `BIGQUERY` and `THOUGHTSPOT`, matching the schema's dialect set
and ordering.

Documentation-only change to keep the three sources in sync. No behavioral or
breaking change.

## Related Issues

None.

## Checklist

### Specification
- [x] Spec changes are included in `core-spec/` and follow the existing structure
- [x] Breaking changes to the spec are clearly called out in the summary (N/A — no breaking change)

<!-- Ontology / Converters / Validation / Examples / Tests: N/A — documentation-only enum sync, no code or behavior change. -->

### Compliance
- [x] No third-party dependencies are added without PMC/IPMC approval
