### PR TITLE
fix(dbt): unqualify compound aggregate arguments per column

### DIFF
--- a/converters/dbt/src/ossie_dbt/expression_utils.py
+++ b/converters/dbt/src/ossie_dbt/expression_utils.py
@@ -28,21 +28,31 @@ def _strip_qualifier(col: str) -> str:
     return col.rsplit(".", 1)[-1] if "." in col else col
 
 
+def _unqualify_column(node: exp.Expression) -> exp.Expression:
+    """Drop the table/schema/database parts of a column reference; other nodes pass through."""
+    return exp.Column(this=node.this) if isinstance(node, exp.Column) else node
+
+
 def _col_name(node: exp.Expression) -> str:
-    """Return the bare (unqualified) column name from a sqlglot expression node."""
+    """Return an aggregate argument with the dataset qualifier stripped from every column reference.
+
+    MSI evaluates a metric's ``expr`` inside its own semantic model, so column
+    references must be unqualified: ``orders.amount`` → ``amount`` and
+    ``orders.gross - orders.tax`` → ``gross - tax``.
+    """
     if isinstance(node, exp.Column):
         return node.name
-    rendered = node.sql()
-    return _strip_qualifier(rendered)
+    return node.transform(_unqualify_column).sql()
 
 
 def _extract_agg_info(expression: str) -> Optional[Tuple[AggregationType, str, Optional[float], bool]]:
     """Parse a SQL aggregation expression using sqlglot.
 
-    Returns ``(agg_type, bare_col, percentile, use_discrete_percentile)`` for recognised patterns,
+    Returns ``(agg_type, expr, percentile, use_discrete_percentile)`` for recognised patterns,
     ``None`` otherwise. ``percentile`` is only set for ``PERCENTILE`` aggregations; it is ``None``
     for all others. ``use_discrete_percentile`` is ``True`` only for ``PERCENTILE_DISC``.
-    The returned column name has any dataset qualifier stripped.
+    ``expr`` is the aggregate argument with the dataset qualifier stripped from every column
+    reference (a bare column name in the common case).
     """
     try:
         tree = sqlglot.parse_one(expression.strip())

--- a/converters/dbt/tests/test_ossie_to_msi.py
+++ b/converters/dbt/tests/test_ossie_to_msi.py
@@ -389,6 +389,54 @@ class TestOssieToMSIMetricConversion:
         assert metric.type_params.metric_aggregation_params is not None
         assert metric.type_params.metric_aggregation_params.semantic_model == "analytics.orders"
 
+    @pytest.mark.parametrize(
+        ("expression", "expected_agg", "expected_expr"),
+        [
+            ("SUM(orders.gross - orders.tax)", AggregationType.SUM, "gross - tax"),
+            ("SUM(COALESCE(orders.tax, 0))", AggregationType.SUM, "COALESCE(tax, 0)"),
+            ("MAX(orders.gross - orders.tax)", AggregationType.MAX, "gross - tax"),
+            ("SUM(amount * 0.5)", AggregationType.SUM, "amount * 0.5"),
+            ("AVG(CAST(orders.tax AS DOUBLE))", AggregationType.AVERAGE, "CAST(tax AS DOUBLE)"),
+            (
+                "COUNT(DISTINCT orders.status || orders.region)",
+                AggregationType.COUNT_DISTINCT,
+                "status || region",
+            ),
+            (
+                "PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY orders.gross - orders.tax)",
+                AggregationType.PERCENTILE,
+                "gross - tax",
+            ),
+        ],
+    )
+    def test_compound_aggregate_argument_is_unqualified_as_a_whole(
+        self, expression: str, expected_agg: AggregationType, expected_expr: str
+    ) -> None:
+        """Every column reference inside the aggregate argument loses its dataset qualifier;
+        the surrounding expression is kept intact rather than sliced at the last dot."""
+        doc = _ossie_doc(
+            datasets=[
+                _ossie_dataset(
+                    "orders",
+                    fields=[
+                        _ossie_field("amount"),
+                        _ossie_field("gross"),
+                        _ossie_field("tax"),
+                        _ossie_field("status"),
+                        _ossie_field("region"),
+                    ],
+                )
+            ],
+            metrics=[_ossie_metric("m", expression)],
+        )
+        result = OssieToMSIConverter().convert(doc).output
+
+        m = result.metrics[0]
+        assert m.type_params.metric_aggregation_params is not None
+        assert m.type_params.metric_aggregation_params.agg == expected_agg
+        assert m.type_params.metric_aggregation_params.semantic_model == "orders"
+        assert m.type_params.expr == expected_expr
+
     def test_percentile_cont_0_5_produces_median(self) -> None:
         doc = _ossie_doc(
             datasets=[_ossie_dataset("orders", fields=[_ossie_field("amount")])],
@@ -499,3 +547,25 @@ class TestOssieToMSIRoundTrip:
         assert m.type_params.metric_aggregation_params.agg == AggregationType.PERCENTILE
         assert m.type_params.metric_aggregation_params.agg_params is not None
         assert m.type_params.metric_aggregation_params.agg_params.use_discrete_percentile is True
+
+    def test_compound_aggregate_argument_survives_round_trip(self) -> None:
+        """Ossie → MSI → Ossie keeps a compound aggregate argument intact."""
+        original = _ossie_doc(
+            datasets=[_ossie_dataset("orders", fields=[_ossie_field("gross"), _ossie_field("tax")])],
+            metrics=[
+                _ossie_metric("net_sales", "SUM(orders.gross - orders.tax)"),
+                _ossie_metric("tax_or_zero", "SUM(COALESCE(orders.tax, 0))"),
+            ],
+        )
+
+        msi = OssieToMSIConverter().convert(original).output
+        ossie_doc = MSIToOssieConverter().convert(msi).output
+
+        metrics = ossie_doc.semantic_model[0].metrics or []
+        expressions = {m.name: m.expression.dialects[0].expression for m in metrics}
+        # msi_to_ossie._qualify_col re-qualifies only bare identifiers,
+        # so the exported argument comes back unqualified.
+        assert expressions == {
+            "net_sales": "SUM(gross - tax)",
+            "tax_or_zero": "SUM(COALESCE(tax, 0))",
+        }


### PR DESCRIPTION
## Summary

`OssieToMSIConverter` turned any aggregate argument that is not a single column into MetricFlow's `expr` by rendering it to text and slicing at the last `.`: `SUM(orders.gross - orders.tax)` became `expr: tax` (and `SUM(orders.tax)` after a round trip), `SUM(COALESCE(orders.tax, 0))` became the unparseable `tax, 0)`, and even the unqualified `SUM(amount * 0.5)` became `5`. No `ConverterIssue` was emitted.

`_col_name` now strips the qualifier from each column reference on the sqlglot tree `_extract_agg_info` already holds (`node.transform(_unqualify_column)`) and renders the result, so `SUM(orders.gross - orders.tax)` yields `expr: gross - tax`, which is what MetricFlow expects inside the semantic model's subquery. The plain-column path, the `_extract_agg_info` return value, and `_strip_qualifier` (still used by `_find_dataset_for_col` for field lookups) are unchanged, so output only changes for arguments that were previously corrupted. Rendering already went through `node.sql()`, so no new normalisation is introduced. No new dependency.

Tests: one parametrized forward test covering arithmetic (`SUM`, `MAX`), function calls, casts, a decimal literal, `COUNT(DISTINCT a || b)` and `PERCENTILE_CONT` over a compound argument, plus one Ossie → MSI → Ossie round trip. All fail on `main` and pass with the change; the 100 existing tests and 5 snapshots are unchanged.

Out of scope, noted in the issue: the fallback path that re-wraps an unrecognised aggregate into `SUM(SUM(...))` on export; `_qualify_col` on export re-qualifying only bare identifiers (its own comment defers compound and quoted expressions), which is why the round-trip test expects `SUM(gross - tax)` and a ratio with a compound numerator now exports as `(SUM(gross - tax)) / (SUM(orders.gross))` (numerically identical within one semantic model; `main` exported the wrong `(SUM(orders.tax)) / (SUM(orders.gross))`); and the SUM_BOOLEAN branch, which still keeps the qualifier in its condition (separate issue).

## Related Issues

Fixes #385

## Testing

```bash
cd converters/dbt
uv run pytest
```

Result: 108 passed (100 existing + 8 new; 5 snapshots unchanged). The 8 new tests fail on `main`.

Also checked locally: the full suite under the declared floor `sqlglot==20.0.0` (108 passed); every Ossie document in `examples/` and `converters/*/tests/` converts byte-identically on `main` and this branch; MetricFlow's `SemanticManifestValidator` accepts manifests containing every new `expr` shape with no errors or warnings; and a differential run of the old and new `_col_name` over 31,608 generated aggregate expressions differs only when the rendered argument contains a dot, with no change in which expressions are recognised.
CI matrix reproduced locally with uv on Python 3.11, 3.12, 3.13 and 3.14 against the locked dependencies (metricflow 0.211.0, sqlglot 30.12.0): 108 passed on each, and again with sqlglot pinned to the declared floor 20.0.0 and to the newest release 30.18.0. Rendering the converted metrics through MetricFlow 0.211 on DuckDB returns the same numbers as the original Ossie expressions for every affected shape, where `main` returns the numbers of the sliced argument.

## Checklist

### Specification
- [ ] Spec changes are included in `core-spec/` and follow the existing structure
- [ ] Spec changes have been discussed on the mailing list or in a linked issue
- [ ] Breaking changes to the spec are clearly called out in the summary

### Ontology
- [ ] Ontology changes in `ontology/` are consistent with spec changes
- [ ] New or modified terms are defined and documented

### Converters
- [x] Converter logic in `converters/` is updated to reflect spec or ontology changes
- [x] New converters include tests under the converter's test directory

### Validation
- [ ] Validation rules in `validation/` are updated if the spec changed
- [ ] New validation cases are covered by tests

### Documentation
- [ ] `docs/` is updated to reflect any user-facing changes
- [ ] New features or behaviors are documented with examples where appropriate
- [ ] `CONTRIBUTING.md` is updated if the contribution process changed

### Examples
- [ ] `examples/` are added or updated for any new spec constructs or converter support

### Tests
- [x] All existing tests pass (`pytest` / CI green)
- [x] New functionality is covered by tests

### Compliance
- [x] ASF license headers are present on all new source files
- [x] No third-party dependencies are added without PMC/IPMC approval

## AI disclosure

Per the ASF Generative Tooling Guidance, this change was prepared with AI assistance; I reviewed and ran everything above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
